### PR TITLE
Modernize site UI, dark mode, newsletter, and tag archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ The author of **iSquared** is Vladimir Ilievski, a data scientist based in Switz
 To know more about Vladimir, click on one of the buttons below.
 
 [<img src="https://img.shields.io/badge/linkedin-%230077B5.svg?&style=for-the-badge&logo=linkedin&logoColor=white" />](https://www.linkedin.com/in/vilievski/)
-[<img src="https://img.shields.io/badge/twitter-%230077B5.svg?&style=for-the-badge&logo=twitter&logoColor=white&color=00acee" />](https://twitter.com/VladOsaurus)
+[<img src="https://img.shields.io/badge/twitter-%230077B5.svg?&style=for-the-badge&logo=twitter&logoColor=white&color=00acee" />](https://x.com/VladOsaurus)
 [<img src="https://img.shields.io/badge/medium-%2312100E.svg?&style=for-the-badge&logo=medium&logoColor=white" />](https://medium.com/@ilievski.vladimir)

--- a/_blog/2020-01-24-why-doing-hackathons.html
+++ b/_blog/2020-01-24-why-doing-hackathons.html
@@ -165,19 +165,7 @@ redirect_from:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 <h2>Conclusion</h2>
 

--- a/_blog/2020-02-08-interactive-dataviz.html
+++ b/_blog/2020-02-08-interactive-dataviz.html
@@ -362,7 +362,7 @@ can visualize all entries in the table using the <i>Parallel Coordinates</i> plo
 <p>
     The full code to run this interactive visualization can be found
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/tree/master/Interactive%20Dataviz" target="_blank" rel=”noopener”>here.</a>
-    For more information please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel=”noopener”>Twitter</a>.
+    For more information please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel=”noopener”>Twitter</a>.
 </p>
 
 <p>
@@ -370,19 +370,7 @@ can visualize all entries in the table using the <i>Parallel Coordinates</i> plo
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 <h2>Conclusion</h2>
 <p>

--- a/_blog/2020-03-10-viz-tools-pt1.html
+++ b/_blog/2020-03-10-viz-tools-pt1.html
@@ -449,23 +449,11 @@ The resulting bar chart is shown in the image below. The interactive web version
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>
 
 <p>
     The full code to run all examples as well as the data set and the scripts to transform it can be
     found <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/tree/master/JavaScript%20Visualization%20Zoo" target="_blank" rel="noopener">here.</a>
-    For more information please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel=”noopener”>Twitter</a>.
+    For more information please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel=”noopener”>Twitter</a>.
 </p>

--- a/_blog/2020-03-24-viz-tools-pt2-1.html
+++ b/_blog/2020-03-24-viz-tools-pt2-1.html
@@ -321,19 +321,7 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 <h2>Summary</h2>
 <p>

--- a/_blog/2020-03-24-viz-tools-pt2-2.html
+++ b/_blog/2020-03-24-viz-tools-pt2-2.html
@@ -358,7 +358,7 @@ For full details regarding the style please refer to the following
 <p>
     The full code and data can be found in the following
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/tree/master/JavaScript%20Visualization%20Zoo" target="_blank" rel="noopener">GitHub repo</a>.
-    For more information, follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="nofollow noopener">Twitter</a>.
+    For more information, follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="nofollow noopener">Twitter</a>.
 </p>
 
 <p>
@@ -366,19 +366,7 @@ For full details regarding the style please refer to the following
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 <h2>Summary</h2>
 

--- a/_blog/2020-04-12-random-walk.html
+++ b/_blog/2020-04-12-random-walk.html
@@ -278,7 +278,7 @@ anim.save(<span style="color: #dd2200; background-color: #fff0f0">&#39;random_wa
 <p>
     The full source code behind this random walk simulation and animation can be found in this
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/tree/master/Random%20Processes" target="_blank" rel="dofollow noopener">GitHub repository</a>.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -286,19 +286,7 @@ anim.save(<span style="color: #dd2200; background-color: #fff0f0">&#39;random_wa
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 <h2>Conclusion</h2>
 

--- a/_blog/2020-04-16-brownian-motion.html
+++ b/_blog/2020-04-16-brownian-motion.html
@@ -314,7 +314,7 @@ anim.save(<span style="color: #dd2200; background-color: #fff0f0">&#39;brownian_
 <p>
     The full source code related to all we have discussed during this blog can be found on
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Random%20Processes/brownian_motion_animation.ipynb", target="_blank" rel="dofollow noopener">GitHub</a>.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -322,19 +322,7 @@ anim.save(<span style="color: #dd2200; background-color: #fff0f0">&#39;brownian_
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 <h2>Conclusion</h2>
 

--- a/_blog/2020-05-01-drifted-brownian-motion.html
+++ b/_blog/2020-05-01-drifted-brownian-motion.html
@@ -228,19 +228,7 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 <h2>Conclusion</h2>
 

--- a/_blog/2020-05-17-geometric-brownian-motion.html
+++ b/_blog/2020-05-17-geometric-brownian-motion.html
@@ -329,7 +329,7 @@ header:
 <p>
     The full source code related to all we have discussed during this blog can be found on
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Random%20Processes/geometric_brownian_motion.ipynb", target="_blank" rel="dofollow noopener">GitHub</a>.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -337,19 +337,7 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 <h2>Key takeaways</h2>
 

--- a/_blog/2020-05-27-riemann-integration.html
+++ b/_blog/2020-05-27-riemann-integration.html
@@ -223,7 +223,7 @@ header:
 <p>
     The full source code related to all we have discussed during this blog can be found on
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Integration/riemann_sums.ipynb" target="_blank" rel="dofollow noopener">GitHub</a>.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -231,19 +231,7 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 <h2>Conclusion</h2>
 

--- a/_blog/2020-07-04-animated-fractals.md
+++ b/_blog/2020-07-04-animated-fractals.md
@@ -293,16 +293,4 @@ them in Python and made interesting animated visualizations of their properties.
 If you liked this tutorial feel free to share it on the social media. Also it would be helpful if you subscribe
 to the mailing list below. You will get updates from time to time.
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_blog/2020-07-07-delicacy-of-data-augmentation.md
+++ b/_blog/2020-07-07-delicacy-of-data-augmentation.md
@@ -69,19 +69,7 @@ context in which the words appear. Second, it is agnostic to the scope of the da
 To mitigate these effects, we need context-aware techniques, which we cover in the next 
 section.
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>
 
 ## ML-Based Substitution
@@ -193,19 +181,7 @@ there is high uncertainty in what direction the generated sentence might continu
 For more information, please follow me on 
 <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener"><b>LinkedIn</b></a>.
 If you like this content you can subscribe to the mailing list below to get similar updates from time to time.
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>
 
 

--- a/_blog/2020-10-01-riemann-stieltjes-integration.html
+++ b/_blog/2020-10-01-riemann-stieltjes-integration.html
@@ -264,23 +264,11 @@ header:
 
 <p>
     If this is something you like and would like to receive similar posts, please subscribe to the mailing list below.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>
     or <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener">LinkedIn</a>.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 <h2>Conclusion</h2>
 

--- a/_blog/2021-01-14-ai-new-normal.html
+++ b/_blog/2021-01-14-ai-new-normal.html
@@ -530,23 +530,11 @@ cls = outputs.last_hidden_state[<span style="color: #0000DD; font-weight: bold">
 
 <p>
     If this is something you like and would like to receive similar posts, please subscribe to the mailing list below.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>
     or <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener">LinkedIn</a>.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 <h2>Conclusion</h2>
 

--- a/_blog/2021-05-02-cellular-automata.html
+++ b/_blog/2021-05-02-cellular-automata.html
@@ -406,22 +406,10 @@ powers_of_two <span style="color: #333333">=</span> np<span style="color: #33333
 <p>
     If this is something you like and would like to receive similar posts, please subscribe to the mailing list below.
     For more information, please follow me on <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener">LinkedIn</a>
-    or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 <h2>Summary: Elementary but not simple</h2>
 

--- a/_blog/2021-12-19-hyperparam-search.html
+++ b/_blog/2021-12-19-hyperparam-search.html
@@ -370,22 +370,10 @@ hip.Experiment.from_iterable(hiplt_data).display()
 <p>
     The source code for the implementation can be found on <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Hyperparameters%20Search/HiPlot_Tutorial.ipynb" target="_blank">GitHub</a>.
     If this is something you like and would like to see similar content you could follow me on <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener">LinkedIn</a>
-    or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>. Additionally, you can subscribe to the mailing list below.
+    or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>. Additionally, you can subscribe to the mailing list below.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 <h1>Summary</h1>
 

--- a/_blog/2023-01-18-code-carbon.md
+++ b/_blog/2023-01-18-code-carbon.md
@@ -179,22 +179,10 @@ by the experiment. An example for the experiment we did above is shown below:
 
 The source code for the implementation can be found on <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Carbon%20Footprint/codecarbon_experiments.ipynb" target="_blank">GitHub</a>.
 If this is something you like and would like to see similar content you could follow me on <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener">LinkedIn</a>
-or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
+or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
 
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>
 
 # Appendix: other initiatives to track the CO2 emissions

--- a/_blog/2023-01-29-chat-gpt-generated-python-tutorial.md
+++ b/_blog/2023-01-29-chat-gpt-generated-python-tutorial.md
@@ -53,20 +53,8 @@ Take a look and downlaod the document by clicking on the button below:
 
 All the resources can be found in this <a href="https://github.com/IlievskiV/the-100-page-chat-gpt-generated-python-tutorial" target="_blank">GitHub Repository</a>.
 If this is something you like and would like to see similar content you could follow me on <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener">LinkedIn</a>
-or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
+or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
 
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>

--- a/_blog/2023-03-15-illustrated-batch-vs-layer-norm.md
+++ b/_blog/2023-03-15-illustrated-batch-vs-layer-norm.md
@@ -182,20 +182,8 @@ on the button below:
 
 For more information, please follow me on 
 <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener"><b>LinkedIn</b></a>
-or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener"><b>Twitter</b></a>.
+or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener"><b>Twitter</b></a>.
 If you like this content you can subscribe to the mailing list below to get similar updates from time to time.
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>

--- a/_blog/2024-08-12-llms-for-recsys.md
+++ b/_blog/2024-08-12-llms-for-recsys.md
@@ -298,19 +298,7 @@ performance across various recommendation tasks.
 showcasing the flexibility and potential of LLMs in recommendation scenarios.
 
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>
 
 
@@ -583,19 +571,7 @@ experiences across the digital realm.
 For more information, please follow me on 
 <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener"><b>LinkedIn</b></a>.
 If you like this content you can subscribe to the mailing list below to get similar updates from time to time.
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>
 
 

--- a/_config.yml
+++ b/_config.yml
@@ -102,7 +102,7 @@ social:
   type                   : # Person or Organization (defaults to Person)
   name                   : "Vladimir Ilievski" # If the user or organization name differs from the site's name
   links: # An array of links to social media profiles
-    - "https://twitter.com/VladOsaurus"
+    - "https://x.com/VladOsaurus"
     - "https://www.linkedin.com/in/vilievski/"
     - "https://medium.com/@ilievski.vladimir"
     - "https://www.reddit.com/user/vladosaurus"
@@ -123,16 +123,16 @@ author:
   location         : "Switzerland 🇨🇭"
   links:
     - label: "LinkedIn"
-      icon: "fab fa-fw fa-linkedin"
+      icon: "fa-brands fa-linkedin"
       url: "https://www.linkedin.com/in/vilievski/"
     - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
-      url: "https://twitter.com/VladOsaurus"
+      icon: "fa-brands fa-square-twitter"
+      url: "https://x.com/VladOsaurus"
     - label: "GitHub"
-      icon: "fab fa-fw fa-github"
+      icon: "fa-brands fa-github"
       url: "https://github.com/IlievskiV"
     - label: "Medium"
-      icon: "fab fa-fw fa-medium"
+      icon: "fa-brands fa-medium"
       url: "https://medium.com/@ilievski.vladimir"
 
 
@@ -140,16 +140,16 @@ author:
 footer:
   links:
     - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
-      url: "https://twitter.com/VladOsaurus"
+      icon: "fa-brands fa-square-twitter"
+      url: "https://x.com/VladOsaurus"
     - label: "GitHub"
-      icon: "fab fa-fw fa-github"
+      icon: "fa-brands fa-github"
       url: "https://github.com/IlievskiV"
     - label: "LinkedIn"
-      icon: "fab fa-fw fa-linkedin"
+      icon: "fa-brands fa-linkedin"
       url: "https://www.linkedin.com/in/vilievski/"
     - label: "Medium"
-      icon: "fab fa-fw fa-medium"
+      icon: "fa-brands fa-medium"
       url: "https://medium.com/@ilievski.vladimir"
 
 # Reading Files

--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -13,7 +13,7 @@ Vladimir Ilievski:
         url: "https://www.linkedin.com/in/vilievski/"
       - label: "Twitter"
         icon: "fab fa-fw fa-twitter-square"
-        url: "https://twitter.com/VladOsaurus"
+        url: "https://x.com/VladOsaurus"
       - label: "GitHub"
         icon: "fab fa-fw fa-github"
         url: "https://github.com/IlievskiV"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -6,7 +6,7 @@ main:
     url: /visualizations/
   - title: "Geeky Coffee Break ☕️"
     url: /tips/
-  - title: "Get in Touch 📬"
-    url: /contactme/
   - title: "$whoami 🪪"
     url: /whoami/
+  - title: "Get in Touch 📬"
+    url: /contactme/

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -1,6 +1,27 @@
 {% assign author = page.author | default: page.authors[0] | default: site.author %}
 {% assign author = site.data.authors[author] | default: author %}
 
+{%- comment -%}
+  Inline SVG brand icons (Simple Icons, CC0) — no Font Awesome kit dependency.
+  Sized via `.author__social svg` in `_sass/custom/_modern.scss` (18x18, currentColor).
+{%- endcomment -%}
+
+{%- capture svg_linkedin -%}<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 1 1 0-4.125 2.062 2.062 0 0 1 0 4.125zM7.119 20.452H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>{%- endcapture -%}
+
+{%- capture svg_twitter -%}<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231 5.45-6.231Zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z"/></svg>{%- endcapture -%}
+
+{%- capture svg_github -%}<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.93 0-1.31.467-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>{%- endcapture -%}
+
+{%- capture svg_medium -%}<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M13.54 12a6.8 6.8 0 0 1-6.77 6.82A6.8 6.8 0 0 1 0 12a6.8 6.8 0 0 1 6.77-6.82A6.8 6.8 0 0 1 13.54 12zM20.96 12c0 3.54-1.51 6.42-3.38 6.42s-3.39-2.88-3.39-6.42 1.52-6.42 3.39-6.42 3.38 2.88 3.38 6.42M24 12c0 3.17-.53 5.75-1.19 5.75-.66 0-1.19-2.58-1.19-5.75s.53-5.75 1.19-5.75C23.47 6.25 24 8.83 24 12z"/></svg>{%- endcapture -%}
+
+{%- capture svg_reddit -%}<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg>{%- endcapture -%}
+
+{%- capture svg_email -%}<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4-8 5-8-5V6l8 5 8-5v2z"/></svg>{%- endcapture -%}
+
+{%- capture svg_link -%}<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7a5 5 0 0 0 0 10h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4a5 5 0 0 0 0-10z"/></svg>{%- endcapture -%}
+
+{%- capture svg_pin -%}<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M12 2a8 8 0 0 0-8 8c0 5.4 7.05 11.5 7.35 11.76a1 1 0 0 0 1.3 0C12.95 21.5 20 15.4 20 10a8 8 0 0 0-8-8zm0 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6z"/></svg>{%- endcapture -%}
+
 <div itemscope itemtype="https://schema.org/Person">
 
   {% if author.avatar %}
@@ -32,232 +53,69 @@
     {% else %}
       <h3 class="author__name" itemprop="name">{{ author.name }}</h3>
     {% endif %}
+
     {% if author.bio %}
       <div class="author__bio" itemprop="description">
         {{ author.bio | markdownify }}
       </div>
     {% endif %}
+
+    {% if author.location %}
+      <div class="author__location" itemprop="homeLocation" itemscope itemtype="https://schema.org/Place">
+        {{ svg_pin }}
+        <span itemprop="name">{{ author.location }}</span>
+      </div>
+    {% endif %}
   </div>
 
   <div class="author__urls-wrapper">
-    <button class="btn btn--inverse">{{ site.data.ui-text[site.locale].follow_label | remove: ":" | default: "Follow" }}</button>
-    <ul class="author__urls social-icons">
-      {% if author.location %}
-        <li itemprop="homeLocation" itemscope itemtype="https://schema.org/Place">
-          <i class="fas fa-fw fa-map-marker-alt" aria-hidden="true"></i> <span itemprop="name">{{ author.location }}</span>
-        </li>
-      {% endif %}
+    {% assign has_socials = false %}
+    {% if author.links and author.links != empty %}{% assign has_socials = true %}{% endif %}
+    {% if author.email %}{% assign has_socials = true %}{% endif %}
 
-      {% if author.links %}
-        {% for link in author.links %}
-          {% if link.label and link.url %}
-            <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer" target="_blank"><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i> {{ link.label }}</a></li>
-          {% endif %}
-        {% endfor %}
-      {% endif %}
+    {% if has_socials %}
+      <p class="author__follow-label">Follow me</p>
+      <ul class="author__socials" aria-label="Social links">
+        {% if author.links %}
+          {% for link in author.links %}
+            {% if link.label and link.url %}
+              {% assign _u = link.url | downcase %}
+              {% assign _l = link.label | downcase %}
+              <li>
+                <a href="{{ link.url }}"
+                   class="author__social"
+                   rel="nofollow noopener noreferrer"
+                   target="_blank"
+                   title="{{ link.label }}"
+                   aria-label="{{ link.label }}"
+                   itemprop="sameAs">
+                  {%- if _u contains 'linkedin' -%}{{ svg_linkedin }}
+                  {%- elsif _u contains 'x.com' or _l == 'twitter' or _l == 'x' -%}{{ svg_twitter }}
+                  {%- elsif _u contains 'github' -%}{{ svg_github }}
+                  {%- elsif _u contains 'medium.com' or _l == 'medium' -%}{{ svg_medium }}
+                  {%- elsif _u contains 'reddit' -%}{{ svg_reddit }}
+                  {%- else -%}{{ svg_link }}
+                  {%- endif -%}
+                  <span class="author__social-label">{{ link.label }}</span>
+                </a>
+              </li>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
 
-      {% if author.uri %}
-        <li>
-          <a href="{{ author.uri }}" itemprop="url">
-            <i class="fas fa-fw fa-link" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].website_label | default: "Website" }}
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.email %}
-        <li>
-          <a href="mailto:{{ author.email }}">
-            <meta itemprop="email" content="{{ author.email }}" />
-            <i class="fas fa-fw fa-envelope-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].email_label | default: "Email" }}
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.keybase %}
-        <li>
-          <a href="https://keybase.io/{{ author.keybase }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fas fa-fw fa-key" aria-hidden="true"></i> Keybase
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.twitter %}
-        <li>
-          <a href="https://twitter.com/{{ author.twitter }}" itemprop="sameAs" rel="nofollow noopener noreferrer" target="_blank">
-            <i class="fab fa-fw fa-twitter-square" aria-hidden="true"></i> Twitter
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.facebook %}
-        <li>
-          <a href="https://www.facebook.com/{{ author.facebook }}" itemprop="sameAs" rel="nofollow noopener noreferrer" target="_blank">
-            <i class="fab fa-fw fa-facebook-square" aria-hidden="true"></i> Facebook
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.linkedin %}
-        <li>
-          <a href="https://www.linkedin.com/in/{{ author.linkedin }}" itemprop="sameAs" rel="nofollow noopener noreferrer" target="_blank">
-            <i class="fab fa-fw fa-linkedin" aria-hidden="true"></i> LinkedIn
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.xing %}
-        <li>
-          <a href="https://www.xing.com/profile/{{ author.xing }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-xing-square" aria-hidden="true"></i> XING
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.instagram %}
-        <li>
-          <a href="https://instagram.com/{{ author.instagram }}" itemprop="sameAs" rel="nofollow noopener noreferrer" target="_blank">
-            <i class="fab fa-fw fa-instagram" aria-hidden="true"></i> Instagram
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.tumblr %}
-        <li>
-          <a href="https://{{ author.tumblr }}.tumblr.com" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-tumblr-square" aria-hidden="true"></i> Tumblr
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.bitbucket %}
-        <li>
-          <a href="https://bitbucket.org/{{ author.bitbucket }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-bitbucket" aria-hidden="true"></i> Bitbucket
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.github %}
-        <li>
-          <a href="https://github.com/{{ author.github }}" itemprop="sameAs" rel="nofollow noopener noreferrer" target="_blank">
-            <i class="fab fa-fw fa-github" aria-hidden="true"></i> GitHub
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.gitlab %}
-        <li>
-          <a href="https://gitlab.com/{{ author.gitlab }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-gitlab" aria-hidden="true"></i> GitLab
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.stackoverflow %}
-        <li>
-          <a href="https://stackoverflow.com/users/{{ author.stackoverflow }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-stack-overflow" aria-hidden="true"></i> Stack Overflow
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.lastfm %}
-        <li>
-          <a href="https://last.fm/user/{{ author.lastfm }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-lastfm-square" aria-hidden="true"></i> Last.fm
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.dribbble %}
-        <li>
-          <a href="https://dribbble.com/{{ author.dribbble }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-dribbble" aria-hidden="true"></i> Dribbble
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.pinterest %}
-        <li>
-          <a href="https://www.pinterest.com/{{ author.pinterest }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-pinterest" aria-hidden="true"></i> Pinterest
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.foursquare %}
-        <li>
-          <a href="https://foursquare.com/{{ author.foursquare }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-foursquare" aria-hidden="true"></i> Foursquare
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.steam %}
-        <li>
-          <a href="https://steamcommunity.com/id/{{ author.steam }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-steam" aria-hidden="true"></i> Steam
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.youtube %}
-        {% if author.youtube contains "://" %}
+        {% if author.email %}
           <li>
-            <a href="{{ author.youtube }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-              <i class="fab fa-fw fa-youtube" aria-hidden="true"></i> YouTube
-            </a>
-          </li>
-        {% else author.youtube %}
-          <li>
-            <a href="https://www.youtube.com/user/{{ author.youtube }}" itemprop="sameAs" rel="nofollow noopener noreferrer" target="_blank">
-              <i class="fab fa-fw fa-youtube" aria-hidden="true"></i> YouTube
+            <a href="mailto:{{ author.email }}"
+               class="author__social"
+               title="Email"
+               aria-label="Email">
+              <meta itemprop="email" content="{{ author.email }}" />
+              {{ svg_email }}
+              <span class="author__social-label">Email</span>
             </a>
           </li>
         {% endif %}
-      {% endif %}
-
-      {% if author.soundcloud %}
-        <li>
-          <a href="https://soundcloud.com/{{ author.soundcloud }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-soundcloud" aria-hidden="true"></i> SoundCloud
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.weibo %}
-        <li>
-          <a href="https://www.weibo.com/{{ author.weibo }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-weibo" aria-hidden="true"></i> Weibo
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.flickr %}
-        <li>
-          <a href="https://www.flickr.com/{{ author.flickr }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-flickr" aria-hidden="true"></i> Flickr
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.codepen %}
-        <li>
-          <a href="https://codepen.io/{{ author.codepen }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-codepen" aria-hidden="true"></i> CodePen
-          </a>
-        </li>
-      {% endif %}
-
-      {% if author.vine %}
-        <li>
-          <a href="https://vine.co/u/{{ author.vine }}" itemprop="sameAs" rel="nofollow noopener noreferrer">
-            <i class="fab fa-fw fa-vine" aria-hidden="true"></i> Vine
-          </a>
-        </li>
-      {% endif %}
-
-      {% include author-profile-custom-links.html %}
-    </ul>
+      </ul>
+    {% endif %}
   </div>
 </div>

--- a/_includes/category-list.html
+++ b/_includes/category-list.html
@@ -19,7 +19,7 @@
     {% for hash in category_hashes %}
       {% assign keyValue = hash | split: '|' %}
       {% capture category_word %}{{ keyValue[1] | strip_newlines }}{% endcapture %}
-      <a class="page__taxonomy-item" rel="tag">{{ category_word }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
+      <a href="{{ category_word | slugify | prepend: path_type | prepend: site.category_archive.path | relative_url }}" class="page__taxonomy-item" rel="tag">{{ category_word }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
     {% endfor %}
     </span>
   </p>

--- a/_includes/comments-providers/scripts.html
+++ b/_includes/comments-providers/scripts.html
@@ -1,3 +1,3 @@
 {% if site.comments.provider and page.comments %}
-    {% include /comments-providers/disqus.html %}s
+    {% include /comments-providers/disqus.html %}
 {% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,22 @@
+{%- comment -%}
+  Inline SVG brand icons (Simple Icons, CC0) — no Font Awesome kit dependency.
+  Sized via `.page__footer-follow .social-icons a svg` in `_sass/custom/_modern.scss`.
+{%- endcomment -%}
+
+{%- capture svg_linkedin -%}<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 1 1 0-4.125 2.062 2.062 0 0 1 0 4.125zM7.119 20.452H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>{%- endcapture -%}
+
+{%- capture svg_twitter -%}<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231 5.45-6.231Zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z"/></svg>{%- endcapture -%}
+
+{%- capture svg_github -%}<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.93 0-1.31.467-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>{%- endcapture -%}
+
+{%- capture svg_medium -%}<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M13.54 12a6.8 6.8 0 0 1-6.77 6.82A6.8 6.8 0 0 1 0 12a6.8 6.8 0 0 1 6.77-6.82A6.8 6.8 0 0 1 13.54 12zM20.96 12c0 3.54-1.51 6.42-3.38 6.42s-3.39-2.88-3.39-6.42 1.52-6.42 3.39-6.42 3.38 2.88 3.38 6.42M24 12c0 3.17-.53 5.75-1.19 5.75-.66 0-1.19-2.58-1.19-5.75s.53-5.75 1.19-5.75C23.47 6.25 24 8.83 24 12z"/></svg>{%- endcapture -%}
+
+{%- capture svg_reddit -%}<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg>{%- endcapture -%}
+
+{%- capture svg_link -%}<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7a5 5 0 0 0 0 10h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4a5 5 0 0 0 0-10z"/></svg>{%- endcapture -%}
+
+{%- capture svg_rss -%}<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M6.503 20.752c0 1.794-1.456 3.248-3.251 3.248-1.796 0-3.252-1.454-3.252-3.248 0-1.794 1.456-3.248 3.252-3.248 1.795.001 3.251 1.454 3.251 3.248zm-6.503-12.572v4.811c6.05.062 10.96 4.966 11.022 11.009h4.817c-.062-8.71-7.118-15.758-15.839-15.82zm0-3.368c10.58.046 19.152 8.594 19.183 19.188h4.817c-.03-13.231-10.755-23.954-24-24v4.812z"/></svg>{%- endcapture -%}
+
 <div class="page__footer-follow">
   <ul class="social-icons">
     {% if site.data.ui-text[site.locale].follow_label %}
@@ -7,18 +26,32 @@
     {% if site.footer.links %}
       {% for link in site.footer.links %}
         {% if link.label and link.url %}
-          <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer"><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i> {{ link.label }}</a></li>
+          {% assign _u = link.url | downcase %}
+          {% assign _l = link.label | downcase %}
+          <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer">
+            {%- if _u contains 'linkedin' -%}{{ svg_linkedin }}
+            {%- elsif _u contains 'x.com' or _l == 'twitter' or _l == 'x' -%}{{ svg_twitter }}
+            {%- elsif _u contains 'github' -%}{{ svg_github }}
+            {%- elsif _u contains 'medium.com' or _l == 'medium' -%}{{ svg_medium }}
+            {%- elsif _u contains 'reddit' -%}{{ svg_reddit }}
+            {%- else -%}{{ svg_link }}
+            {%- endif -%}
+            {{ link.label }}
+          </a></li>
         {% endif %}
       {% endfor %}
     {% endif %}
 
-    <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/blog.xml' | absolute_url }}{% endif %}"><i class="fas fa-fw fa-rss-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
+    <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/blog.xml' | absolute_url }}{% endif %}">{{ svg_rss }} {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
   </ul>
 </div>
-<br/>
+
 <div class="page__footer-copyright">
-  <center>
-    <a rel="noopener license nofollow" target="_blank" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png"/></a><br/>
-    &copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }}. This work is licensed under a <a rel="license noopener nofollow" target="_blank" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>.
-  </center>
+  <a rel="noopener license nofollow" target="_blank" href="http://creativecommons.org/licenses/by-nc-sa/4.0/" class="page__footer-cc-badge">
+    <img alt="Creative Commons License" src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png">
+  </a>
+  <p>
+    &copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }}. This work is licensed under a
+    <a rel="license noopener nofollow" target="_blank" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>.
+  </p>
 </div>

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,5 +1,33 @@
 <!-- start custom head snippets -->
-<link href="https://fonts.googleapis.com/css?family=Montserrat&display=swap" rel="stylesheet">
+
+<!-- Theme color (matches modern light/dark navbar).
+     The two media-scoped metas drive the system-preference fallback; the
+     unscoped meta is what the explicit theme toggle in modern.js updates
+     (its selector is meta[name="theme-color"]:not([media])). -->
+<meta name="theme-color" content="#ffffff">
+<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#0b1020" media="(prefers-color-scheme: dark)">
+<meta name="color-scheme" content="light dark">
+
+<!-- Apply persisted theme as early as possible to avoid flash -->
+<script>
+  (function () {
+    try {
+      var stored = localStorage.getItem('theme');
+      var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      var theme = stored || (prefersDark ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', theme);
+    } catch (e) {}
+  })();
+</script>
+
+<!-- Preconnect to font CDN for snappier loads -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
+<!-- Modern type stack: Inter (UI/body), Space Grotesk (display), JetBrains Mono (code) -->
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
 <script src="{{ site.baseurl }}/assets/js/lazysizes.min.js" async></script>
 
 <!-- insert favicons. use https://realfavicongenerator.net/ -->

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -9,11 +9,12 @@
     <div class="masthead__menu">
       <nav id="site-nav" class="greedy-nav">
         {% unless logo_path == empty %}
-          <a class="site-logo" href="{{ '/' | relative_url }}"><img src="{{ logo_path | relative_url }}" alt=""></a>
+          <a class="site-logo" href="{{ '/' | relative_url }}" aria-label="{{ site.title }} home">
+            <img src="{{ logo_path | relative_url }}" alt="{{ site.title }} logo">
+          </a>
         {% endunless %}
         <a class="site-title" href="{{ '/' | relative_url }}">
           {{ site.masthead_title | default: site.title }}
-          {% if site.subtitle %}<span class="site-subtitle">{{ site.subtitle }}</span>{% endif %}
         </a>
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}
@@ -22,20 +23,37 @@
             {%- else -%}
               {%- assign url = link.url | relative_url -%}
             {%- endif -%}
+            {%- if link.url == '/whoami/' -%}
+              {%- assign link_class = 'masthead__cta' -%}
+            {%- else -%}
+              {%- assign link_class = '' -%}
+            {%- endif -%}
             <li class="masthead__menu-item">
-              <a href="{{ url }}" {% if link.description %}title="{{ link.description }}"{% endif %}>{{ link.title }}</a>
+              <a href="{{ url }}"{% if link_class != '' %} class="{{ link_class }}"{% endif %}{% if link.description %} title="{{ link.description }}"{% endif %}>{{ link.title }}</a>
             </li>
           {%- endfor -%}
         </ul>
+
         {% if site.search == true %}
-        <button class="search__toggle" type="button">
+        <button class="search__toggle" type="button" aria-label="Toggle search">
           <span class="visually-hidden">{{ site.data.ui-text[site.locale].search_label | default: "Toggle search" }}</span>
           <svg class="icon" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15.99 16">
             <path d="M15.5,13.12L13.19,10.8a1.69,1.69,0,0,0-1.28-.55l-0.06-.06A6.5,6.5,0,0,0,5.77,0,6.5,6.5,0,0,0,2.46,11.59a6.47,6.47,0,0,0,7.74.26l0.05,0.05a1.65,1.65,0,0,0,.5,1.24l2.38,2.38A1.68,1.68,0,0,0,15.5,13.12ZM6.4,2A4.41,4.41,0,1,1,2,6.4,4.43,4.43,0,0,1,6.4,2Z" transform="translate(-.01)"></path>
           </svg>
         </button>
         {% endif %}
-        <button class="greedy-nav__toggle hidden" type="button">
+
+        <button class="theme-toggle" type="button" aria-label="Toggle dark mode" title="Toggle dark mode">
+          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="4"/>
+            <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
+          </svg>
+          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+          </svg>
+        </button>
+
+        <button class="greedy-nav__toggle hidden" type="button" aria-label="Toggle menu">
           <span class="visually-hidden">{{ site.data.ui-text[site.locale].menu_label | default: "Toggle menu" }}</span>
           <div class="navicon"></div>
         </button>

--- a/_includes/newsletter.html
+++ b/_includes/newsletter.html
@@ -1,0 +1,44 @@
+{%- comment -%}
+  Modern newsletter signup. Use a unique form id per render so multiple
+  embeds on the same page don't collide. Use {% include newsletter.html variant="sidebar" %}
+  for the narrow sidebar variant.
+{%- endcomment -%}
+{%- assign nl_id = include.id | default: 'iss-nl' -%}
+{%- assign nl_uid = include.uid | default: page.url | append: '-' | append: nl_id | replace: '/', '-' -%}
+{%- if include.variant == 'sidebar' -%}
+  {%- assign nl_extra_class = 'iss-newsletter--sidebar' -%}
+{%- else -%}
+  {%- assign nl_extra_class = '' -%}
+{%- endif -%}
+
+<section class="iss-newsletter {{ nl_extra_class }}" id="mc_embed_signup-{{ nl_uid }}">
+  <div class="iss-newsletter__inner">
+    <h3 class="iss-newsletter__title">{{ include.title | default: "Join the iSquared mailing list" }}</h3>
+    <p class="iss-newsletter__hint">{{ include.hint | default: "New posts, visualizations and tips &mdash; straight to your inbox. No spam, unsubscribe anytime." }}</p>
+
+    <form
+      action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0"
+      method="post"
+      name="mc-embedded-subscribe-form"
+      class="iss-newsletter__form validate"
+      target="_blank"
+      novalidate
+    >
+      <label class="iss-newsletter__sr" for="mce-EMAIL-{{ nl_uid }}">Email address</label>
+      <input
+        class="iss-newsletter__input email"
+        type="email"
+        name="EMAIL"
+        id="mce-EMAIL-{{ nl_uid }}"
+        placeholder="you@domain.com"
+        required
+        autocomplete="email"
+      >
+      <button class="iss-newsletter__btn" type="submit" name="subscribe">Subscribe</button>
+
+      <div aria-hidden="true" style="position:absolute;left:-5000px;">
+        <input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value="">
+      </div>
+    </form>
+  </div>
+</section>

--- a/_includes/page__related.html
+++ b/_includes/page__related.html
@@ -1,0 +1,49 @@
+{% comment %}
+  Renders the "You may also enjoy" section using tag overlap.
+
+  Algorithm (no scoring, keeps Liquid simple):
+    1. Build a candidate pool from the blog, visualizations and tips
+       collections (collection names match `_config.yml`).
+    2. Sort reverse-chronologically so the most recent posts win ties.
+    3. Keep any candidate that shares at least one tag with the current
+       page; skip the current page itself; cap at 4 results.
+{% endcomment %}
+
+{% if page.related and page.tags and page.tags.size > 0 %}
+  {% assign current_url = page.url %}
+  {% assign current_tags = page.tags %}
+
+  {% assign candidates = site.blog | concat: site.visualizations | concat: site.tips %}
+  {% assign candidates = candidates | sort: "date" | reverse %}
+
+  {% assign related = "" | split: "" %}
+  {% for doc in candidates %}
+    {% if doc.url == current_url %}{% continue %}{% endif %}
+    {% if doc.tags and doc.tags.size > 0 %}
+      {% assign overlap = false %}
+      {% for t in doc.tags %}
+        {% if current_tags contains t %}
+          {% assign overlap = true %}
+          {% break %}
+        {% endif %}
+      {% endfor %}
+      {% if overlap %}
+        {% assign related = related | push: doc %}
+      {% endif %}
+    {% endif %}
+    {% if related.size >= 4 %}{% break %}{% endif %}
+  {% endfor %}
+
+  {% if related.size > 0 %}
+    <div class="page__related">
+      {% if site.data.ui-text[site.locale].related_label %}
+        <h4 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h4>
+      {% endif %}
+      <div class="grid__wrapper">
+        {% for post in related %}
+          {% include archive-single.html type="grid" %}
+        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
+{% endif %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -12,6 +12,9 @@
   <script src="https://kit.fontawesome.com/4eee35f757.js" async></script>
 {% endif %}
 
+<!-- iSquared modern remodel script: theme toggle, reveal-on-scroll, nav shadow -->
+<script src="{{ '/assets/js/custom/modern.js' | relative_url }}" defer></script>
+
 {% if site.search == true or page.layout == "search" %}
   {% include_cached search/algolia-search-scripts.html %}
 {% endif %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -2,45 +2,25 @@
   <div class="sidebar sticky">
   {% if page.author_profile or layout.author_profile %}{% include author-profile.html %}{% endif %}
   {% if page.sidebar %}
-    {% for s in page.sidebar %}
-      {% if s.image %}
+    {% for sb in page.sidebar %}
+      {% if sb.image %}
         <img src=
-        {% if s.image contains "://" %}
-          "{{ s.image }}"
+        {% if sb.image contains "://" %}
+          "{{ sb.image }}"
         {% else %}
-          "{{ s.image | relative_url }}"
+          "{{ sb.image | relative_url }}"
         {% endif %}
-        alt="{% if s.image_alt %}{{ s.image_alt }}{% endif %}">
+        alt="{% if sb.image_alt %}{{ sb.image_alt }}{% endif %}">
       {% endif %}
-      {% if s.title %}<h3>{{ s.title }}</h3>{% endif %}
-      {% if s.text %}{{ s.text | markdownify }}{% endif %}
-      {% if s.nav %}{% include nav_list nav=s.nav %}{% endif %}
+      {% if sb.title %}<h3>{{ sb.title }}</h3>{% endif %}
+      {% if sb.text %}{{ sb.text | markdownify }}{% endif %}
+      {% if sb.nav %}{% include nav_list nav=sb.nav %}{% endif %}
     {% endfor %}
     {% if page.sidebar.nav %}
       {% include nav_list nav=page.sidebar.nav %}
     {% endif %}
   {% endif %}
 
-    <link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
-    <div id="mc_embed_signup" style="background:#fff; clear:left; font-size: 1.25em; font-family: Montserrat, sans-serif; width:240px;">
-        <form action="https://github.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-            <div id="mc_embed_signup_scroll">
-                <h3>Subscribe</h3>
-                <div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
-                <div class="mc-field-group">
-                    <label for="mce-EMAIL">Email Address  <span class="asterisk">*</span></label>
-                    <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" style="width:230px;">
-                </div>
-                <div id="mce-responses" class="clear">
-                    <div class="response" id="mce-error-response" style="display:none"></div>
-                    <div class="response" id="mce-success-response" style="display:none"></div>
-                </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-                <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-                <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-            </div>
-        </form>
-    </div>
-      <script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script>
-      <script type='text/javascript' src='../../assets/js/mailchimp.js'></script>
+    {% include newsletter.html variant="sidebar" id="sidebar" title="Subscribe" hint="New posts & visualizations in your inbox." %}
   </div>
 {% endif %}

--- a/_includes/social-share.html
+++ b/_includes/social-share.html
@@ -1,11 +1,16 @@
+{% assign locale = include.locale | default: site.locale %}
 <section class="page__share">
-  {% if site.data.ui-text[site.locale].share_on_label %}
-    <p class="page__share-title">{{ site.data.ui-text[site.locale].share_on_label | default: "Share on" }}</p>
-  {% endif %}
+  <h4 class="page__share-title">{{ site.data.ui-text[locale].share_on_label | default: "Share on" }}</h4>
 
-  <a href="https://twitter.com/intent/tweet?{% if site.twitter.username %}via={{ site.twitter.username | url_encode }}&{% endif %}text={{ page.title | url_encode }}%20{{ page.url | absolute_url | url_encode }}" class="btn btn--twitter" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Twitter"><i class="fab fa-fw fa-twitter" aria-hidden="true"></i><span></span></a>
+  <a href="https://x.com/intent/tweet?{% if site.twitter.username %}via={{ site.twitter.username | url_encode }}&{% endif %}text={{ page.title | url_encode }}%20{{ page.url | absolute_url | url_encode }}" class="btn btn--x" aria-label="Share on X" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[locale].share_on_label | default: 'Share on' }} X">
+    <svg viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" width="1em" height="1em"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg><span> X</span>
+  </a>
 
-  <a href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | absolute_url | url_encode }}" class="btn btn--facebook" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Facebook"><i class="fab fa-fw fa-facebook" aria-hidden="true"></i><span></span></a>
+  <a href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | absolute_url | url_encode }}" class="btn btn--facebook" aria-label="Share on Facebook" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[locale].share_on_label | default: 'Share on' }} Facebook">
+    <svg viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" width="1em" height="1em"><path d="M9.101 23.691v-7.98H6.627v-3.667h2.474v-1.58c0-4.085 1.848-5.978 5.858-5.978.401 0 .955.042 1.468.103a8.68 8.68 0 0 1 1.141.195v3.325a8.623 8.623 0 0 0-.653-.036 26.805 26.805 0 0 0-.733-.009c-.707 0-1.259.096-1.675.309a1.686 1.686 0 0 0-.679.622c-.258.42-.374.995-.374 1.752v1.297h3.919l-.386 2.103-.287 1.564h-3.246v8.245C19.396 23.238 24 18.179 24 12.044c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.628 3.874 10.35 9.101 11.647Z"/></svg><span> Facebook</span>
+  </a>
 
-  <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url | url_encode }}" class="btn btn--linkedin" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} LinkedIn"><i class="fab fa-fw fa-linkedin" aria-hidden="true"></i><span></span></a>
+  <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url }}" class="btn btn--linkedin" aria-label="Share on LinkedIn" onclick="window.open(this.href, 'window', 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" title="{{ site.data.ui-text[locale].share_on_label | default: 'Share on' }} LinkedIn">
+    <svg viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" width="1em" height="1em"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.063 2.063 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg><span> LinkedIn</span>
+  </a>
 </section>

--- a/_includes/tag-list.html
+++ b/_includes/tag-list.html
@@ -19,7 +19,7 @@
     {% for hash in tag_hashes %}
       {% assign keyValue = hash | split: '|' %}
       {% capture tag_word %}{{ keyValue[1] | strip_newlines }}{% endcapture %}
-      <a class="page__taxonomy-item" rel="tag">{{ tag_word }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
+      <a href="{{ tag_word | slugify | prepend: path_type | prepend: site.tag_archive.path | relative_url }}" class="page__taxonomy-item" rel="tag">{{ tag_word }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
     {% endfor %}
     </span>
   </p>

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -68,41 +68,5 @@ layout: default
   </article>
 
 
-  {% comment %}<!-- show posts by related tags when `related: true` -->{% endcomment %}
-  {% if page.related %}
-    {% assign maxRelated = 4 %}
-    {% assign minCommonTags =  1 %}
-    {% assign maxRelatedCounter = 0 %}
-    {% assign posts = site.blogs | concat: site.visualizations | concat: site.tips %}
-
-    {% for post in posts %}
-      {% assign sameTagCount = 0 %}
-      {% for this_tag in post.tags %}
-        {% if post.url != page.url %}
-          {% if page.tags contains this_tag %}
-            {% assign sameTagCount = sameTagCount | plus: 1 %}
-          {% endif %}
-        {% endif %}
-      {% endfor %}
-
-      {% if sameTagCount >= minCommonTags %}
-        {% if maxRelatedCounter == 0 %}
-          <div class="page__related">
-            {% if site.data.ui-text[site.locale].related_label %}
-              <h4 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h4>
-            {% endif %}
-            <div class="grid__wrapper">
-        {% endif %}
-        {% include archive-single.html type="grid" %}
-        {% assign maxRelatedCounter = maxRelatedCounter | plus: 1 %}
-        {% if maxRelatedCounter >= maxRelated %}
-          {% break %}
-        {% endif %}
-      {% endif %}
-    {% endfor %}
-    {% if maxRelatedCounter > 0 %}
-        </div>
-      </div>
-    {% endif %}
-  {% endif %}
+  {% include page__related.html %}
 </div>

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -1,47 +1,36 @@
 ---
-title: "Page Not Found"
-excerpt: "Page not found. Your pixels are in another canvas."
+title: "404 — Page Not Found"
+excerpt: "Your pixels are in another canvas."
 sitemap: false
 permalink: /404.html
+layout: splash
+classes:
+  - is-404
 ---
 
-<style type="text/css" media="screen">
-  .container {
-    margin: 10px auto;
-    max-width: 600px;
-    text-align: center;
-  }
-  h1 {
-    margin: 30px 0;
-    font-size: 4em;
-    line-height: 1;
-    letter-spacing: -1px;
-  }
-</style>
+<div class="not-found">
+  <div class="not-found__digits" aria-hidden="true">
+    <span>4</span><span class="not-found__zero">0</span><span>4</span>
+  </div>
 
-<div class="container">
-<h1>404</h1>
+  <h1 class="not-found__title">Lost in the manifold</h1>
+  <p class="not-found__lead">
+    The page you were after isn't here. It either moved, never existed, or
+    quietly collapsed into a different dimension.
+  </p>
 
-<p><strong>Page not found :(</strong></p>
-<p>The requested page could not be found.</p>
+  <div class="not-found__actions">
+    <a href="/" class="btn btn--info btn--large">Back to home</a>
+    <a href="/blog/" class="btn btn--inverse btn--large">Browse the blog</a>
+    <a href="/visualizations/" class="btn btn--inverse btn--large">See visualizations</a>
+  </div>
 
-<figure style="width: full;">
-  <img data-src="{{ site.url }}{{ site.baseurl }}/assets/logos/isquared_logo_header.jpeg" class="lazyload" alt="Website logo">
-</figure>
-<br/>
-
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-    <form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-        <div id="mc_embed_signup_scroll">
-        <label for="mce-EMAIL">Join the iSquared mailing list</label>
-        <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-        <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-        <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-        </div>
-    </form>
-</div>
-
+  <div class="not-found__suggest">
+    <p class="not-found__suggest-title">Or try one of these:</p>
+    <ul>
+      <li><a href="/tips/">Quick tips & tricks</a></li>
+      <li><a href="/whoami/">$whoami — about the author</a></li>
+      <li><a href="/contactme/">Get in touch</a></li>
+    </ul>
+  </div>
 </div>

--- a/_pages/contactme.html
+++ b/_pages/contactme.html
@@ -7,36 +7,70 @@ redirect_from:
     - /contact/
 ---
 
-
 <script src="https://www.google.com/recaptcha/api.js"></script>
 
-<p>Want to get in touch? Fill out the form below to send me a message and I will get back to you as soon as possible!</p>
-<form action="https://smartforms.dev/submit/5edd2c670e4ff6358c36cd95" method="POST" >
-  <div class="control-group">
-    <div class="form-group floating-label-form-group controls">
-      <label>Name</label>
-      <input type="text" class="form-control" placeholder="Name" id="name" name="name" required data-validation-required-message="Please enter your name.">
-      <p class="help-block text-danger"></p>
-    </div>
+<section class="iss-contact">
+  <div class="iss-contact__inner">
+    <h2 class="iss-contact__title">Get in touch</h2>
+    <p class="iss-contact__hint">Drop me a message and I'll get back to you as soon as possible.</p>
+
+    <form action="https://smartforms.dev/submit/5edd2c670e4ff6358c36cd95" method="POST" class="iss-contact__form">
+      <div class="iss-contact__field">
+        <label class="iss-contact__label" for="iss-contact-name">Name</label>
+        <input
+          class="iss-contact__input"
+          type="text"
+          id="iss-contact-name"
+          name="name"
+          placeholder="Your name"
+          autocomplete="name"
+          required
+        >
+      </div>
+
+      <div class="iss-contact__field">
+        <label class="iss-contact__label" for="iss-contact-email">Email address</label>
+        <input
+          class="iss-contact__input"
+          type="email"
+          id="iss-contact-email"
+          name="email"
+          placeholder="you@domain.com"
+          autocomplete="email"
+          required
+        >
+      </div>
+
+      <div class="iss-contact__field">
+        <label class="iss-contact__label" for="iss-contact-subject">
+          Subject <span class="iss-contact__optional">(optional)</span>
+        </label>
+        <input
+          class="iss-contact__input"
+          type="text"
+          id="iss-contact-subject"
+          name="subject"
+          placeholder="What's this about?"
+        >
+      </div>
+
+      <div class="iss-contact__field">
+        <label class="iss-contact__label" for="iss-contact-message">Message</label>
+        <textarea
+          class="iss-contact__textarea"
+          id="iss-contact-message"
+          name="message"
+          rows="8"
+          placeholder="Write your message here..."
+          required
+        ></textarea>
+      </div>
+
+      <div class="g-recaptcha iss-contact__recaptcha" data-sitekey="6LfeNAEVAAAAAEBtYWV3OAYTjSO-KYccPJ_b-uaJ"></div>
+
+      <div class="iss-contact__actions">
+        <button class="iss-contact__btn" type="submit">Send message</button>
+      </div>
+    </form>
   </div>
-  <div class="control-group">
-    <div class="form-group floating-label-form-group controls">
-      <label>Email Address</label>
-      <input type="email" class="form-control" placeholder="Email Address" id="email" name="email" required data-validation-required-message="Please enter your email address.">
-      <p class="help-block text-danger"></p>
-    </div>
-  </div>
-  <div class="control-group">
-    <div class="form-group floating-label-form-group controls">
-      <label>Message</label>
-      <textarea rows="8" class="form-control" placeholder="Message" id="message" name="message" required data-validation-required-message="Please enter a message."></textarea>
-      <p class="help-block text-danger"></p>
-            </div>
-  </div>
-  <br>
-  <div id="success"></div>
-  <div class="form-group">
-    <button type="submit" class="btn btn-primary" id="sendMessageButtonxxx">Send</button>
-  </div>
-  <div class="g-recaptcha" data-sitekey="6LfeNAEVAAAAAEBtYWV3OAYTjSO-KYccPJ_b-uaJ"></div>
-</form>
+</section>

--- a/_pages/tag-archive.html
+++ b/_pages/tag-archive.html
@@ -1,0 +1,80 @@
+---
+title: "Posts by Tag"
+layout: archive
+permalink: /tags/
+author_profile: true
+---
+
+{% comment %}
+  Aggregate tags across the custom collections (_blog, _visualizations, _tips)
+  since this site does not use the default _posts collection. site.tags would be
+  empty here, so we build our own tag → docs map.
+{% endcomment %}
+
+{% assign all_docs = site.blog | concat: site.visualizations | concat: site.tips %}
+
+{% comment %} Collect every unique tag value across all docs {% endcomment %}
+{% assign all_tags = "" | split: "" %}
+{% for doc in all_docs %}
+  {% if doc.tags %}
+    {% for t in doc.tags %}
+      {% assign all_tags = all_tags | push: t %}
+    {% endfor %}
+  {% endif %}
+{% endfor %}
+
+{% assign unique_tags = all_tags | uniq | sort_natural %}
+
+{% if unique_tags.size > 0 %}
+  <section class="iss-tag-cloud" aria-label="All tags">
+    <h2 class="iss-tag-cloud__title">Browse by tag</h2>
+    <ul class="iss-tag-cloud__list">
+      {% for tag in unique_tags %}
+        {% assign slug = tag | slugify %}
+        {% assign count = 0 %}
+        {% for doc in all_docs %}
+          {% if doc.tags contains tag %}{% assign count = count | plus: 1 %}{% endif %}
+        {% endfor %}
+        <li>
+          <a class="iss-tag-cloud__chip" href="#{{ slug }}">
+            <span class="iss-tag-cloud__chip-name">{{ tag }}</span>
+            <span class="iss-tag-cloud__chip-count">{{ count }}</span>
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+
+  {% for tag in unique_tags %}
+    {% assign slug = tag | slugify %}
+    {% assign tag_docs = all_docs | where_exp: "doc", "doc.tags contains tag" | sort: "date" | reverse %}
+
+    <section class="iss-tag-section" id="{{ slug }}">
+      <h2 class="iss-tag-section__title">
+        <span class="iss-tag-section__hash">#</span>{{ tag }}
+        <span class="iss-tag-section__count">{{ tag_docs.size }} post{% if tag_docs.size != 1 %}s{% endif %}</span>
+      </h2>
+
+      <ul class="iss-tag-section__list">
+        {% for post in tag_docs %}
+          <li class="iss-tag-section__item">
+            <a class="iss-tag-section__link" href="{{ post.url | relative_url }}">
+              <span class="iss-tag-section__post-title">{{ post.title }}</span>
+              {% if post.excerpt %}
+                <span class="iss-tag-section__post-excerpt">{{ post.excerpt | strip_html | truncate: 140 }}</span>
+              {% endif %}
+              <span class="iss-tag-section__post-meta">
+                {% if post.date %}<time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%b %-d, %Y" }}</time>{% endif %}
+                <span class="iss-tag-section__collection">· {{ post.collection }}</span>
+              </span>
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+
+      <a class="iss-tag-section__back" href="#page-title">↑ Back to top</a>
+    </section>
+  {% endfor %}
+{% else %}
+  <p>No tagged posts yet.</p>
+{% endif %}

--- a/_pages/whoami.html
+++ b/_pages/whoami.html
@@ -11,6 +11,25 @@ redirect_from:
 - /about/
 ---
 
+{%- comment -%}
+  Inline SVG icon library used throughout this page. Defined once with Liquid
+  `capture` blocks so the rendered HTML emits real inline <svg> elements with
+  no external dependency (the site's Font Awesome kit was unreliable).
+  All metadata icons share viewBox 0 0 24 24 and inherit color via
+  fill="currentColor" so they pick up `.cv-meta` / `.social-pill-row` colors.
+  Brand icons use the canonical Simple Icons paths.
+{%- endcomment -%}
+{%- capture svg_briefcase -%}<svg viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" width="1em" height="1em"><path d="M20 7h-4V5a3 3 0 0 0-3-3h-2a3 3 0 0 0-3 3v2H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2zM10 5a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2h-4V5zm10 14H4V9h16v10z"/></svg>{%- endcapture -%}
+{%- capture svg_building -%}<svg viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" width="1em" height="1em"><path d="M4 2v20h7v-4h2v4h7V2H4zm4 16H6v-2h2v2zm0-4H6v-2h2v2zm0-4H6V8h2v2zm0-4H6V4h2v2zm5 8h-2v-2h2v2zm0-4h-2V8h2v2zm0-4h-2V4h2v2zm5 12h-2v-2h2v2zm0-4h-2v-2h2v2zm0-4h-2V8h2v2zm0-4h-2V4h2v2z"/></svg>{%- endcapture -%}
+{%- capture svg_calendar -%}<svg viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" width="1em" height="1em"><path d="M19 4h-1V2h-2v2H8V2H6v2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2zm0 16H5V10h14v10zm0-12H5V6h14v2z"/></svg>{%- endcapture -%}
+{%- capture svg_map_pin -%}<svg viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" width="1em" height="1em"><path d="M12 2a7 7 0 0 0-7 7c0 5.25 7 13 7 13s7-7.75 7-13a7 7 0 0 0-7-7zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5z"/></svg>{%- endcapture -%}
+{%- capture svg_grad_cap -%}<svg viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" width="1em" height="1em"><path d="M12 3 1 9l4 2.18v6L12 21l7-3.82v-6l2-1.09V17h2V9zm6.82 6L12 12.72 5.18 9 12 5.28zM17 15.99l-5 2.73-5-2.73v-3.72L12 15l5-2.73z"/></svg>{%- endcapture -%}
+{%- capture svg_star -%}<svg viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" width="1em" height="1em"><path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg>{%- endcapture -%}
+{%- capture svg_linkedin -%}<svg viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" width="1em" height="1em"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.063 2.063 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>{%- endcapture -%}
+{%- capture svg_twitter -%}<svg viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" width="1em" height="1em"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>{%- endcapture -%}
+{%- capture svg_medium -%}<svg viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" width="1em" height="1em"><path d="M13.54 12a6.8 6.8 0 0 1-6.77 6.82A6.8 6.8 0 0 1 0 12a6.8 6.8 0 0 1 6.77-6.82A6.8 6.8 0 0 1 13.54 12zm7.42 0c0 3.54-1.51 6.42-3.38 6.42-1.87 0-3.39-2.88-3.39-6.42s1.52-6.42 3.39-6.42 3.38 2.88 3.38 6.42M24 12c0 3.17-.53 5.75-1.19 5.75-.66 0-1.19-2.58-1.19-5.75s.53-5.75 1.19-5.75C23.47 6.25 24 8.83 24 12z"/></svg>{%- endcapture -%}
+{%- capture svg_github -%}<svg viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" width="1em" height="1em"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>{%- endcapture -%}
+
 <hr>
 
 <p>TL;DR you can find my <i>boring</i> CV <a href="http://bit.ly/2rvD13U" target="_blank">here</a>.</p>
@@ -29,37 +48,13 @@ redirect_from:
     background, check the content below.
 </p>
 
-<p>To hear more from me and the content I create on <strong>iSquared</strong> follow me on my social media profiles:</p>
+<p>To hear more from me and the content I create on <strong>iSquared</strong>, follow me on my social media:</p>
 
-<ul style="list-style-type: none; margin: 0; padding: 0;" class="align-left">
-
-    <li style="display:inline;">
-        <a href="https://www.linkedin.com/in/vilievski" rel="nofollow noopener noreferrer" target="_blank">
-            <img style="width: 40px;" data-src="{{ site.url }}{{ site.baseurl }}/assets/logos/linkedin_logo.png"
-                class="lazyload" alt="LinkedIn logo" />
-        </a>
-    </li>
-
-    <li style="display:inline;">
-        <a href="https://twitter.com/VladOsaurus" rel="nofollow noopener noreferrer" target="_blank">
-            <img style="width: 40px;" data-src="{{ site.url }}{{ site.baseurl }}/assets/logos/twitter_logo.png"
-                class="lazyload" alt="Twitter logo" />
-        </a>
-    </li>
-
-    <li style="display:inline;">
-        <a href="https://medium.com/@ilievski.vladimir" rel="nofollow noopener noreferrer" target="_blank">
-            <img style="width: 40px;" data-src="{{ site.url }}{{ site.baseurl }}/assets/logos/medium_logo.png"
-                class="lazyload" alt="Medium logo" />
-        </a>
-    </li>
-
-    <li style="display:inline;">
-        <a href="https://github.com/IlievskiV" rel="nofollow noopener noreferrer" target="_blank">
-            <img style="width: 40px;" data-src="{{ site.url }}{{ site.baseurl }}/assets/logos/github_logo.png"
-                class="lazyload" alt="GitHub logo" />
-        </a>
-    </li>
+<ul class="social-pill-row">
+    <li><a href="https://www.linkedin.com/in/vilievski" rel="nofollow noopener noreferrer" target="_blank" aria-label="LinkedIn">{{ svg_linkedin }} LinkedIn</a></li>
+    <li><a href="https://x.com/VladOsaurus" rel="nofollow noopener noreferrer" target="_blank" aria-label="Twitter">{{ svg_twitter }} Twitter</a></li>
+    <li><a href="https://medium.com/@ilievski.vladimir" rel="nofollow noopener noreferrer" target="_blank" aria-label="Medium">{{ svg_medium }} Medium</a></li>
+    <li><a href="https://github.com/IlievskiV" rel="nofollow noopener noreferrer" target="_blank" aria-label="GitHub">{{ svg_github }} GitHub</a></li>
 </ul>
 <br />
 <br/>
@@ -77,18 +72,10 @@ redirect_from:
         </td>
         <td style="border-bottom: none; width: 83%; padding:0px 0px 0px 10px;">
             <ul style="list-style-type: none; margin: 0; padding: 0;">
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/briefcase.png"><strong>Senior Data
-                        Scientist</strong></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/company.png"><a
-                        href="https://www.frontiersin.org/" target="_blank"><i>Frontiers</i></a></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/calendar.png"><i>Mid August 2021 -
-                        Present</i></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/location.png"><i>Lausanne, Switzerland</i>
-                </li>
+                <li class="cv-meta">{{ svg_briefcase }}<span><strong>Senior Data Scientist</strong></span></li>
+                <li class="cv-meta">{{ svg_building }}<span><a href="https://www.frontiersin.org/" target="_blank"><i>Frontiers</i></a></span></li>
+                <li class="cv-meta">{{ svg_calendar }}<span><i>Mid August 2021 - Present</i></span></li>
+                <li class="cv-meta">{{ svg_map_pin }}<span><i>Lausanne, Switzerland</i></span></li>
             </ul>
         </td>
     </tr>
@@ -150,18 +137,10 @@ redirect_from:
         </td>
         <td style="border-bottom: none; width: 83%; padding:10px 0px 0px 10px;">
             <ul style="list-style-type: none; margin: 0; padding: 0;">
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/briefcase.png"><strong>Machine Learning
-                        Engineer</strong></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/company.png"><a href="https://igenius.ai/"
-                        target="_blank"><i>iGenius, the AI company</i></a></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/calendar.png"><i>June 2018 - Mid August
-                        2021</i></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/location.png"><i>Lausanne, Switzerland</i>
-                </li>
+                <li class="cv-meta">{{ svg_briefcase }}<span><strong>Machine Learning Engineer</strong></span></li>
+                <li class="cv-meta">{{ svg_building }}<span><a href="https://igenius.ai/" target="_blank"><i>iGenius, the AI company</i></a></span></li>
+                <li class="cv-meta">{{ svg_calendar }}<span><i>June 2018 - Mid August 2021</i></span></li>
+                <li class="cv-meta">{{ svg_map_pin }}<span><i>Lausanne, Switzerland</i></span></li>
             </ul>
         </td>
     </tr>
@@ -210,18 +189,10 @@ redirect_from:
         </td>
         <td style="border-bottom: none; width: 83%; padding:0px 0px 0px 10px;">
             <ul style="list-style-type: none; margin: 0; padding: 0;">
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/briefcase.png"><strong>Master Thesis
-                        Project</strong></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/company.png"><a
-                        href="https://www.swisscom.ch/" target="_blank"><i>Swisscom</i></a></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/calendar.png"><i>September 2017 - March
-                        2018</i></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/location.png"><i>Lausanne, Switzerland</i>
-                </li>
+                <li class="cv-meta">{{ svg_briefcase }}<span><strong>Master Thesis Project</strong></span></li>
+                <li class="cv-meta">{{ svg_building }}<span><a href="https://www.swisscom.ch/" target="_blank"><i>Swisscom</i></a></span></li>
+                <li class="cv-meta">{{ svg_calendar }}<span><i>September 2017 - March 2018</i></span></li>
+                <li class="cv-meta">{{ svg_map_pin }}<span><i>Lausanne, Switzerland</i></span></li>
             </ul>
         </td>
     </tr>
@@ -251,18 +222,10 @@ redirect_from:
         </td>
         <td style="border-bottom: none; width: 83%; padding:10px 0px 0px 10px;">
             <ul style="list-style-type: none; margin: 0; padding: 0;">
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/briefcase.png"><strong>Artificial
-                        Intelligence Intern</strong></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/company.png"><a href="https://www.pmi.com/"
-                        target="_blank"><i>Philip Morris International</i></a></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/calendar.png"><i>February 2017 - July
-                        2017</i></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/location.png"><i>Lausanne, Switzerland</i>
-                </li>
+                <li class="cv-meta">{{ svg_briefcase }}<span><strong>Artificial Intelligence Intern</strong></span></li>
+                <li class="cv-meta">{{ svg_building }}<span><a href="https://www.pmi.com/" target="_blank"><i>Philip Morris International</i></a></span></li>
+                <li class="cv-meta">{{ svg_calendar }}<span><i>February 2017 - July 2017</i></span></li>
+                <li class="cv-meta">{{ svg_map_pin }}<span><i>Lausanne, Switzerland</i></span></li>
             </ul>
         </td>
     </tr>
@@ -306,18 +269,10 @@ redirect_from:
 
         <td style="border-bottom: none; width: 83%; padding:0px 0px 0px 10px;">
             <ul style="list-style-type: none; margin: 0; padding: 0;">
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/university.png"><strong>Masters Degree in
-                        Computer Sciences</strong></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/company.png"><a href="https://www.epfl.ch/"
-                        target="_blank"><i>École polytechnique fédérale de Lausanne (EPFL)</i></a></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/calendar.png"><i>September 2015 - March
-                        2018</i></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/location.png"><i>Lausanne, Switzerland</i>
-                </li>
+                <li class="cv-meta">{{ svg_grad_cap }}<span><strong>Masters Degree in Computer Sciences</strong></span></li>
+                <li class="cv-meta">{{ svg_building }}<span><a href="https://www.epfl.ch/" target="_blank"><i>École polytechnique fédérale de Lausanne (EPFL)</i></a></span></li>
+                <li class="cv-meta">{{ svg_calendar }}<span><i>September 2015 - March 2018</i></span></li>
+                <li class="cv-meta">{{ svg_map_pin }}<span><i>Lausanne, Switzerland</i></span></li>
             </ul>
         </td>
     </tr>
@@ -345,18 +300,10 @@ redirect_from:
         </td>
         <td style="border-bottom: none; width: 83%; padding:10px 0px 0px 10px;">
             <ul style="list-style-type: none; margin: 0; padding: 0;">
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/university.png"><strong>Bachelor Degree in
-                        Computer Sciences</strong></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/company.png"><a
-                        href="https://www.finki.ukim.mk/en" target="_blank"><i>Faculty of Computer Science and
-                            Engineering (FCSE)</i></a></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/calendar.png"><i>September 2011 - July
-                        2015</i></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/location.png"><i>Skopje, Macedonia</i></li>
+                <li class="cv-meta">{{ svg_grad_cap }}<span><strong>Bachelor Degree in Computer Sciences</strong></span></li>
+                <li class="cv-meta">{{ svg_building }}<span><a href="https://www.finki.ukim.mk/en" target="_blank"><i>Faculty of Computer Science and Engineering (FCSE)</i></a></span></li>
+                <li class="cv-meta">{{ svg_calendar }}<span><i>September 2011 - July 2015</i></span></li>
+                <li class="cv-meta">{{ svg_map_pin }}<span><i>Skopje, Macedonia</i></span></li>
             </ul>
         </td>
     </tr>
@@ -395,19 +342,10 @@ redirect_from:
         </td>
         <td style="border-bottom: none; width: 83%; padding:0px 0px 0px 10px;">
             <ul style="list-style-type: none; margin: 0; padding: 0;">
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/briefcase.png"><strong>Open Source Student
-                        Developer</strong></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/company.png"><a
-                        href="https://summerofcode.withgoogle.com/" target="_blank"><i>Google Summer of Code</i></a>
-                </li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/calendar.png"><i>May 2017 - August 2017</i>
-                </li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/location.png"><i>CERN, Geneva,
-                        Switzerland</i></li>
+                <li class="cv-meta">{{ svg_briefcase }}<span><strong>Open Source Student Developer</strong></span></li>
+                <li class="cv-meta">{{ svg_building }}<span><a href="https://summerofcode.withgoogle.com/" target="_blank"><i>Google Summer of Code</i></a></span></li>
+                <li class="cv-meta">{{ svg_calendar }}<span><i>May 2017 - August 2017</i></span></li>
+                <li class="cv-meta">{{ svg_map_pin }}<span><i>CERN, Geneva, Switzerland</i></span></li>
             </ul>
         </td>
     </tr>
@@ -444,18 +382,10 @@ redirect_from:
         </td>
         <td style="border-bottom: none; width: 83%; padding:10px 0px 0px 10px;">
             <ul style="list-style-type: none; margin: 0; padding: 0;">
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/briefcase.png"><strong>Research
-                        Scholar</strong></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/company.png"><a href="https://www.epfl.ch/"
-                        target="_blank"><i>Rigorous System Design Lab (RiSD)</i></a></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/calendar.png"><i>September 2015 - January
-                        2017</i></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/location.png"><i>Lausanne, Switzerland</i>
-                </li>
+                <li class="cv-meta">{{ svg_briefcase }}<span><strong>Research Scholar</strong></span></li>
+                <li class="cv-meta">{{ svg_building }}<span><a href="https://www.epfl.ch/" target="_blank"><i>Rigorous System Design Lab (RiSD)</i></a></span></li>
+                <li class="cv-meta">{{ svg_calendar }}<span><i>September 2015 - January 2017</i></span></li>
+                <li class="cv-meta">{{ svg_map_pin }}<span><i>Lausanne, Switzerland</i></span></li>
             </ul>
         </td>
     </tr>
@@ -490,17 +420,10 @@ redirect_from:
         </td>
         <td style="border-bottom: none; width: 83%; padding:10px 0px 0px 10px;">
             <ul style="list-style-type: none; margin: 0; padding: 0;">
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/briefcase.png"><strong>Summer
-                        Student</strong></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/company.png"><a href="https://home.cern/"
-                        target="_blank"><i>CERN</i></a></li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/calendar.png"><i>June 2014 - August 2014</i>
-                </li>
-                <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-                        src="{{ site.url }}{{ site.baseurl }}/assets/icons/location.png"><i>Geneva, Switzerland</i></li>
+                <li class="cv-meta">{{ svg_briefcase }}<span><strong>Summer Student</strong></span></li>
+                <li class="cv-meta">{{ svg_building }}<span><a href="https://home.cern/" target="_blank"><i>CERN</i></a></span></li>
+                <li class="cv-meta">{{ svg_calendar }}<span><i>June 2014 - August 2014</i></span></li>
+                <li class="cv-meta">{{ svg_map_pin }}<span><i>Geneva, Switzerland</i></span></li>
             </ul>
         </td>
     </tr>
@@ -815,18 +738,10 @@ redirect_from:
 
 <h1 id="Accomplishments">Accomplishments</h1>
 <ul style="list-style-type: none; margin: 0; padding: 0;">
-    <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-            src="{{ site.url }}{{ site.baseurl }}/assets/icons/star.png">Dean's list at the Faculty of Computer Science
-        and Engineering (FCSE) for top 10 out of 600 students</li>
-    <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-            src="{{ site.url }}{{ site.baseurl }}/assets/icons/star.png">Scholarship from Ministry of Education for top
-        10% Computer Science students in Macedonia</li>
-    <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-            src="{{ site.url }}{{ site.baseurl }}/assets/icons/star.png">Bronze medals at the Macedonian Mathematics
-        Olympiad in 2010 for top 20 out of 400 contestants</li>
-    <li style="margin: 0;"><img style="height: 16px; width: 16px; margin-right: 5px;"
-            src="{{ site.url }}{{ site.baseurl }}/assets/icons/star.png">Second prize at the National Competition in
-        Mathematics in 2010</li>
+    <li class="cv-meta">{{ svg_star }}<span>Dean's list at the Faculty of Computer Science and Engineering (FCSE) for top 10 out of 600 students</span></li>
+    <li class="cv-meta">{{ svg_star }}<span>Scholarship from Ministry of Education for top 10% Computer Science students in Macedonia</span></li>
+    <li class="cv-meta">{{ svg_star }}<span>Bronze medals at the Macedonian Mathematics Olympiad in 2010 for top 20 out of 400 contestants</span></li>
+    <li class="cv-meta">{{ svg_star }}<span>Second prize at the National Competition in Mathematics in 2010</span></li>
 </ul>
 <br />
 

--- a/_sass/custom/_modern.scss
+++ b/_sass/custom/_modern.scss
@@ -1,0 +1,3033 @@
+/* =============================================================================
+   iSquared — Modern Remodel
+   Layered on top of Minimal Mistakes via a single override partial.
+   Uses CSS custom properties so every component reacts to light / dark mode.
+   ============================================================================= */
+
+/* -----------------------------------------------------------------------------
+   1. Design tokens
+   -------------------------------------------------------------------------- */
+:root {
+  /* Type */
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif;
+  --font-display: "Space Grotesk", "Inter", sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas,
+    monospace;
+
+  /* Radii & shadows */
+  --radius-sm: 8px;
+  --radius-md: 14px;
+  --radius-lg: 20px;
+  --radius-xl: 28px;
+
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06),
+    0 1px 3px rgba(15, 23, 42, 0.04);
+  --shadow-md: 0 4px 12px rgba(15, 23, 42, 0.08),
+    0 2px 4px rgba(15, 23, 42, 0.04);
+  --shadow-lg: 0 20px 40px -12px rgba(15, 23, 42, 0.18),
+    0 8px 16px -8px rgba(15, 23, 42, 0.08);
+  --shadow-glow: 0 0 0 1px rgba(99, 102, 241, 0.18),
+    0 12px 32px -8px rgba(99, 102, 241, 0.35);
+
+  /* Motion */
+  --ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --t-fast: 0.15s;
+  --t-base: 0.25s;
+  --t-slow: 0.45s;
+
+  /* Layout */
+  --container-max: 1200px;
+  --content-max: 760px;
+  --nav-height: 68px;
+}
+
+/* Light theme tokens (default) */
+:root,
+[data-theme="light"] {
+  --bg: #fbfbfd;
+  --bg-elev: #ffffff;
+  --bg-soft: #f3f4f8;
+  --bg-muted: #eef0f6;
+  --surface: rgba(255, 255, 255, 0.72);
+  --surface-strong: rgba(255, 255, 255, 0.92);
+
+  --text: #0f172a;
+  --text-muted: #4b5563;
+  --text-subtle: #6b7280;
+  --text-inverse: #ffffff;
+
+  --border: rgba(15, 23, 42, 0.08);
+  --border-strong: rgba(15, 23, 42, 0.14);
+
+  --accent: #6366f1;
+  --accent-strong: #4f46e5;
+  --accent-soft: rgba(99, 102, 241, 0.12);
+  --accent-2: #ec4899;
+  --accent-3: #06b6d4;
+
+  --code-bg: #f6f7fb;
+  --code-text: #0f172a;
+  --code-border: rgba(15, 23, 42, 0.08);
+
+  --grad-hero: radial-gradient(
+      1200px 600px at 10% -10%,
+      rgba(99, 102, 241, 0.25),
+      transparent 60%
+    ),
+    radial-gradient(
+      900px 500px at 90% 10%,
+      rgba(236, 72, 153, 0.2),
+      transparent 60%
+    ),
+    radial-gradient(
+      700px 500px at 50% 110%,
+      rgba(6, 182, 212, 0.2),
+      transparent 60%
+    );
+}
+
+/* Dark theme tokens */
+[data-theme="dark"] {
+  --bg: #0b1020;
+  --bg-elev: #111733;
+  --bg-soft: #141a36;
+  --bg-muted: #1a2147;
+  --surface: rgba(17, 23, 51, 0.65);
+  --surface-strong: rgba(17, 23, 51, 0.9);
+
+  --text: #e7ecf5;
+  --text-muted: #b0b7c9;
+  --text-subtle: #8a93ab;
+  --text-inverse: #0b1020;
+
+  --border: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.14);
+
+  --accent: #818cf8;
+  --accent-strong: #a5b4fc;
+  --accent-soft: rgba(129, 140, 248, 0.16);
+  --accent-2: #f472b6;
+  --accent-3: #22d3ee;
+
+  --code-bg: #0d1230;
+  --code-text: #e7ecf5;
+  --code-border: rgba(255, 255, 255, 0.08);
+
+  --grad-hero: radial-gradient(
+      1200px 600px at 10% -10%,
+      rgba(129, 140, 248, 0.35),
+      transparent 60%
+    ),
+    radial-gradient(
+      900px 500px at 90% 10%,
+      rgba(244, 114, 182, 0.28),
+      transparent 60%
+    ),
+    radial-gradient(
+      700px 500px at 50% 110%,
+      rgba(34, 211, 238, 0.22),
+      transparent 60%
+    );
+}
+
+/* Smooth transition between themes */
+html {
+  color-scheme: light dark;
+}
+html[data-theme="dark"] {
+  color-scheme: dark;
+}
+body,
+.masthead,
+.page__footer,
+.archive__item,
+.feature__wrapper,
+.author__avatar,
+.author__content,
+.author__urls {
+  transition: background-color var(--t-base) var(--ease),
+    color var(--t-base) var(--ease), border-color var(--t-base) var(--ease);
+}
+
+/* -----------------------------------------------------------------------------
+   2. Base — body, typography, scrollbars, links, selection
+   -------------------------------------------------------------------------- */
+html,
+body {
+  background: var(--bg);
+  color: var(--text);
+}
+
+body {
+  font-family: var(--font-sans) !important;
+  font-feature-settings: "ss01", "cv11", "kern";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  line-height: 1.65;
+}
+
+::selection {
+  background: var(--accent-soft);
+  color: var(--text);
+}
+
+/* Custom scrollbar */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-strong) transparent;
+}
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+*::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: 999px;
+  border: 2px solid var(--bg);
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--accent);
+}
+
+/* Headings */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.page__title,
+.archive__item-title,
+.page__hero--overlay .page__title {
+  font-family: var(--font-display) !important;
+  color: var(--text);
+  letter-spacing: -0.02em;
+  font-weight: 700;
+}
+
+h1 {
+  font-size: #{"clamp(2rem, 1.4rem + 2.4vw, 3.25rem)"};
+  line-height: 1.1;
+}
+h2 {
+  font-size: #{"clamp(1.5rem, 1.1rem + 1.4vw, 2.25rem)"};
+  line-height: 1.18;
+  margin-top: 2.25em;
+}
+h3 {
+  font-size: #{"clamp(1.2rem, 1rem + 0.8vw, 1.5rem)"};
+  line-height: 1.25;
+}
+
+p,
+li {
+  color: var(--text);
+}
+
+/* Links */
+a,
+.page__content a {
+  color: var(--accent-strong);
+  text-decoration: none;
+  background-image: linear-gradient(var(--accent), var(--accent));
+  background-size: 0% 1.5px;
+  background-repeat: no-repeat;
+  background-position: 0 100%;
+  transition: background-size var(--t-base) var(--ease),
+    color var(--t-fast) var(--ease);
+}
+a:hover,
+.page__content a:hover {
+  color: var(--accent);
+  background-size: 100% 1.5px;
+}
+
+/* Inline code & pre */
+code,
+kbd,
+samp {
+  font-family: var(--font-mono) !important;
+  font-size: 0.9em;
+  background: var(--code-bg);
+  color: var(--code-text);
+  border: 1px solid var(--code-border);
+  border-radius: 6px;
+  padding: 0.12em 0.4em;
+}
+pre,
+div.highlighter-rouge,
+figure.highlight {
+  background: var(--code-bg) !important;
+  border: 1px solid var(--code-border) !important;
+  border-radius: var(--radius-md) !important;
+  box-shadow: var(--shadow-sm);
+}
+pre code,
+.highlight code {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--code-text);
+}
+
+/* Horizontal rule */
+hr {
+  border: 0;
+  height: 1px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    var(--border-strong),
+    transparent
+  );
+  margin: 2.5rem 0;
+}
+
+/* Tables */
+table {
+  background: var(--bg-elev);
+  border-color: var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+thead {
+  background: var(--bg-soft);
+}
+th,
+td {
+  border-color: var(--border) !important;
+}
+
+/* Blockquote */
+blockquote {
+  border-left: 4px solid var(--accent);
+  background: var(--bg-soft);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  padding: 1rem 1.25rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* Notices (info / warning / etc.) */
+.notice,
+.notice--primary,
+.notice--info,
+.notice--warning,
+.notice--success,
+.notice--danger {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--bg-soft);
+  color: var(--text);
+  box-shadow: var(--shadow-sm);
+}
+
+/* Reduce motion */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition: none !important;
+    animation: none !important;
+  }
+}
+
+/* -----------------------------------------------------------------------------
+   3. Masthead — sticky, glass, dark-mode toggle, refined nav
+   -------------------------------------------------------------------------- */
+.masthead {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: var(--surface) !important;
+  -webkit-backdrop-filter: saturate(180%) blur(14px);
+  backdrop-filter: saturate(180%) blur(14px);
+  border-bottom: 1px solid var(--border) !important;
+  box-shadow: 0 1px 0 var(--border);
+  transition: box-shadow var(--t-base) var(--ease),
+    background-color var(--t-base) var(--ease);
+}
+.masthead.is-scrolled {
+  box-shadow: 0 6px 24px -12px rgba(15, 23, 42, 0.18),
+    0 1px 0 var(--border);
+}
+
+.masthead__inner-wrap {
+  /* Slightly wider than the global content container so all 5 nav links,
+     the highlighted CTA, search/theme buttons, and the site title/logo
+     fit comfortably on common 1280–1440px laptop widths without being
+     pushed into the greedy-nav overflow menu. */
+  max-width: 1320px;
+  padding: 0.5rem 1rem;
+}
+
+.greedy-nav {
+  background: transparent !important;
+  min-height: var(--nav-height);
+  align-items: center;
+  gap: 0.15rem;
+}
+
+.greedy-nav .site-logo {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 0.55rem;
+  background-image: none;
+}
+.greedy-nav .site-logo img {
+  height: 30px;
+  width: 30px;
+  object-fit: contain;
+  border-radius: 7px;
+  background: var(--bg-soft);
+  padding: 3px;
+  border: 1px solid var(--border);
+  transition: transform var(--t-fast) var(--ease);
+}
+.greedy-nav .site-logo:hover img {
+  transform: scale(1.06) rotate(-2deg);
+}
+
+.greedy-nav .site-title {
+  font-family: var(--font-display) !important;
+  font-weight: 700;
+  font-size: 1.15rem;
+  color: var(--text) !important;
+  letter-spacing: -0.01em;
+  display: inline-flex;
+  align-items: center;
+  background-image: none;
+}
+.greedy-nav .site-subtitle {
+  display: none;
+}
+
+.greedy-nav a {
+  color: var(--text-muted) !important;
+  font-weight: 500;
+  font-size: 0.88rem;
+  padding: 0.4rem 0.75rem !important;
+  border-radius: 999px;
+  background-image: none;
+  transition: color var(--t-fast) var(--ease),
+    background-color var(--t-fast) var(--ease);
+}
+.greedy-nav a:hover {
+  color: var(--text) !important;
+  background-color: var(--bg-soft) !important;
+}
+
+.greedy-nav .visible-links a:before {
+  display: none !important;
+}
+
+/* Search button */
+.greedy-nav button.search__toggle,
+.greedy-nav .search__toggle {
+  color: var(--text-muted);
+  background: transparent;
+  border-radius: 999px;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.35rem;
+  transition: background-color var(--t-fast) var(--ease),
+    color var(--t-fast) var(--ease);
+}
+.greedy-nav button.search__toggle:hover {
+  background: var(--bg-soft);
+  color: var(--text);
+}
+
+.greedy-nav__toggle {
+  color: var(--text);
+  background: transparent;
+  border-radius: 999px;
+}
+
+/* Theme toggle button (injected via JS into masthead) */
+.theme-toggle {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--bg-elev);
+  color: var(--text);
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  margin-left: 0.35rem;
+  transition: transform var(--t-fast) var(--ease),
+    background-color var(--t-fast) var(--ease),
+    border-color var(--t-fast) var(--ease);
+}
+.theme-toggle:hover {
+  transform: rotate(-12deg);
+  background: var(--bg-soft);
+  border-color: var(--border-strong);
+}
+.theme-toggle svg {
+  width: 16px;
+  height: 16px;
+}
+.theme-toggle .icon-moon {
+  display: none;
+}
+[data-theme="dark"] .theme-toggle .icon-moon {
+  display: block;
+}
+[data-theme="dark"] .theme-toggle .icon-sun {
+  display: none;
+}
+
+/* Search overlay */
+.initial-content + .search-content,
+.search-content {
+  background: var(--surface-strong) !important;
+  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(16px);
+  color: var(--text);
+}
+.search-content input.search-input {
+  color: var(--text) !important;
+  border-bottom-color: var(--border-strong) !important;
+}
+
+/* -----------------------------------------------------------------------------
+   4. Hero (homepage splash + collection page header)
+   -------------------------------------------------------------------------- */
+.page__hero,
+.page__hero--overlay {
+  position: relative;
+  border-radius: 0;
+  padding: #{"clamp(4rem, 8vw, 8rem)"} 0 #{"clamp(3rem, 6vw, 6rem)"} !important;
+  overflow: hidden;
+  background-size: cover;
+  background-position: center;
+}
+
+.page__hero--overlay {
+  background-color: var(--bg) !important;
+  color: var(--text-inverse);
+}
+
+/* Animated gradient overlay layered above the hero image */
+.page__hero--overlay::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--grad-hero);
+  pointer-events: none;
+  animation: heroPulse 14s ease-in-out infinite alternate;
+}
+.page__hero--overlay::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(11, 16, 32, 0.35),
+    rgba(11, 16, 32, 0.55)
+  );
+  pointer-events: none;
+}
+[data-theme="light"] .page__hero--overlay::after {
+  background: linear-gradient(
+    to bottom,
+    rgba(15, 23, 42, 0.45),
+    rgba(15, 23, 42, 0.65)
+  );
+}
+
+@keyframes heroPulse {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  100% {
+    transform: translate3d(0, -2%, 0) scale(1.05);
+  }
+}
+
+.page__hero--overlay .wrapper {
+  position: relative;
+  z-index: 2;
+  max-width: var(--container-max);
+  padding: 0 1.5rem;
+}
+
+.page__hero--overlay .page__title {
+  font-family: var(--font-display) !important;
+  font-size: #{"clamp(2.4rem, 1.8rem + 3vw, 4.5rem)"} !important;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+  background: linear-gradient(
+    180deg,
+    #ffffff 0%,
+    rgba(255, 255, 255, 0.85) 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 1rem;
+  text-shadow: none;
+}
+
+.page__hero--overlay .page__lead {
+  font-size: #{"clamp(1rem, 0.95rem + 0.4vw, 1.25rem)"};
+  color: rgba(255, 255, 255, 0.92);
+  max-width: 680px;
+  font-weight: 400;
+  line-height: 1.55;
+  text-shadow: 0 1px 12px rgba(0, 0, 0, 0.25);
+}
+
+.page__hero--overlay .page__meta {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.page__hero-caption {
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(6px);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+}
+
+/* Hero CTAs */
+.page__hero--overlay .btn {
+  margin: 0.4rem 0.4rem 0.4rem 0;
+}
+
+/* -----------------------------------------------------------------------------
+   5. Buttons — modern pill style
+   -------------------------------------------------------------------------- */
+/* All button rules use !important on background/border/color so they win against
+   the theme's `.page__content .btn` selectors without specificity gymnastics. */
+.btn {
+  display: inline-flex !important;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.65rem 1.1rem !important;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 0.92rem;
+  border-radius: 999px !important;
+  border: 1px solid transparent !important;
+  background: var(--bg-elev) !important;
+  color: var(--text) !important;
+  text-decoration: none;
+  background-image: none;
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease),
+    background-color var(--t-fast) var(--ease),
+    color var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
+  line-height: 1.2;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+  background-image: none;
+}
+
+.btn--info,
+.btn--primary {
+  background: linear-gradient(
+    135deg,
+    var(--accent),
+    var(--accent-strong)
+  ) !important;
+  color: #fff !important;
+  border-color: transparent !important;
+  box-shadow: 0 8px 24px -8px rgba(99, 102, 241, 0.55);
+}
+.btn--info:hover,
+.btn--primary:hover {
+  filter: brightness(1.05);
+  box-shadow: 0 12px 28px -8px rgba(99, 102, 241, 0.65);
+  color: #fff !important;
+}
+
+.btn--inverse {
+  background: var(--bg-elev) !important;
+  color: var(--text) !important;
+  border: 1px solid var(--border-strong) !important;
+}
+.btn--inverse:hover {
+  background: var(--bg-soft) !important;
+}
+
+.btn--success {
+  background: linear-gradient(135deg, #10b981, #059669) !important;
+  color: #fff !important;
+  border-color: transparent !important;
+}
+.btn--warning {
+  background: linear-gradient(135deg, #f59e0b, #d97706) !important;
+  color: #fff !important;
+  border-color: transparent !important;
+}
+.btn--danger {
+  background: linear-gradient(135deg, #ef4444, #dc2626) !important;
+  color: #fff !important;
+  border-color: transparent !important;
+}
+
+.btn--light-outline {
+  color: #fff !important;
+  background: rgba(255, 255, 255, 0.08) !important;
+  border-color: rgba(255, 255, 255, 0.4) !important;
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+}
+.btn--light-outline:hover {
+  background: rgba(255, 255, 255, 0.18) !important;
+  border-color: rgba(255, 255, 255, 0.6) !important;
+}
+
+.btn--large {
+  padding: 0.85rem 1.4rem !important;
+  font-size: 1rem;
+}
+
+/* -----------------------------------------------------------------------------
+   6. Cards — feature_row & archive grid
+   -------------------------------------------------------------------------- */
+.feature__wrapper {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  /* Fluid gap: ~2rem on small screens, scales up to 2.5rem on wide viewports. */
+  gap: #{"clamp(2rem, 1.5rem + 1.5vw, 2.5rem)"} !important;
+  border-bottom: 0;
+  padding-bottom: 0;
+  margin: 1.5rem 0 2.5rem;
+}
+
+.feature__item {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  float: none;
+  display: flex;
+}
+
+.feature__item .archive__item {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  width: 100%;
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--t-base) var(--ease),
+    box-shadow var(--t-base) var(--ease),
+    border-color var(--t-base) var(--ease);
+}
+
+.feature__item .archive__item:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-lg);
+  border-color: var(--border-strong);
+}
+
+.feature__item .archive__item-teaser {
+  border-radius: 0;
+  margin: 0;
+  background: var(--bg-soft);
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+}
+.feature__item .archive__item-teaser img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.6s var(--ease);
+}
+.feature__item .archive__item:hover .archive__item-teaser img {
+  transform: scale(1.05);
+}
+
+.feature__item .archive__item-body {
+  padding: 1.25rem 1.4rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.feature__item .archive__item-title {
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  line-height: 1.3;
+  margin: 0 0 0.6rem;
+  color: var(--text);
+  letter-spacing: -0.01em;
+}
+
+.feature__item .archive__item-excerpt {
+  color: var(--text-muted);
+  font-size: 0.94rem;
+  line-height: 1.55;
+  flex: 1;
+}
+
+.feature__item .archive__item-excerpt + p {
+  margin-top: 1rem;
+  margin-bottom: 0;
+}
+
+/* "left" / "right" feature variants — collapse to grid for consistency */
+.feature__item--left,
+.feature__item--right,
+.feature__item--center {
+  display: flex;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  float: none;
+  clear: none;
+}
+.feature__item--left .archive__item,
+.feature__item--right .archive__item,
+.feature__item--center .archive__item {
+  display: flex;
+  flex-direction: column;
+}
+.feature__item--left .archive__item-teaser,
+.feature__item--right .archive__item-teaser,
+.feature__item--center .archive__item-teaser {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  border-radius: 0;
+}
+.feature__item--left .archive__item-body,
+.feature__item--right .archive__item-body,
+.feature__item--center .archive__item-body {
+  width: 100%;
+  padding: 1.25rem 1.4rem 1.4rem;
+}
+
+/* Archive (collection list) cards — blog/, visualizations/, tips/ */
+.archive {
+  margin-top: 1.5rem;
+}
+
+.grid__wrapper {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  /* Match `.feature__wrapper` so blog/visualizations/tips listings breathe equally. */
+  gap: #{"clamp(2rem, 1.5rem + 1.5vw, 2.5rem)"} !important;
+}
+
+.grid__item {
+  margin: 0;
+  width: 100%;
+  float: none;
+}
+
+.grid__item .archive__item {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  transition: transform var(--t-base) var(--ease),
+    box-shadow var(--t-base) var(--ease),
+    border-color var(--t-base) var(--ease);
+}
+.grid__item .archive__item:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-lg);
+  border-color: var(--border-strong);
+}
+
+.grid__item .archive__item-teaser {
+  background: var(--bg-soft);
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: 0;
+  margin: 0;
+}
+.grid__item .archive__item-teaser img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.6s var(--ease);
+}
+.grid__item .archive__item:hover .archive__item-teaser img {
+  transform: scale(1.05);
+}
+
+.grid__item .archive__item-body {
+  padding: 1.25rem 1.4rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  flex: 1;
+}
+
+.grid__item .archive__item-title {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  line-height: 1.3;
+  margin: 0;
+}
+.grid__item .archive__item-title a {
+  color: var(--text);
+  background-image: none;
+}
+.grid__item .archive__item-title a:hover {
+  color: var(--accent);
+}
+
+.grid__item .archive__item-excerpt {
+  color: var(--text-muted);
+  font-size: 0.92rem;
+}
+
+.archive__item-caption {
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.7rem;
+}
+
+/* -----------------------------------------------------------------------------
+   7. Single post layout — sidebar, content, TOC, related
+   -------------------------------------------------------------------------- */
+.layout--single .page,
+.page {
+  padding-top: 1rem;
+}
+
+.page__inner-wrap {
+  max-width: var(--container-max);
+  margin: 0 auto;
+}
+
+.page__content {
+  font-size: 1.05rem;
+  line-height: 1.75;
+  color: var(--text);
+}
+
+.page__content figure {
+  background: var(--bg-soft);
+  border-radius: var(--radius-md);
+  padding: 0.5rem;
+  border: 1px solid var(--border);
+}
+.page__content figure img {
+  border-radius: var(--radius-sm);
+}
+.page__content figcaption {
+  color: var(--text-subtle);
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+/* Page meta (date, read time, etc.) */
+.page__meta,
+.page__date {
+  color: var(--text-subtle);
+  font-size: 0.85rem;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+/* Tags & categories chips */
+.page__taxonomy .page__taxonomy-item,
+.page__taxonomy a {
+  background: var(--accent-soft);
+  color: var(--accent-strong) !important;
+  border: 0;
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  background-image: none;
+  margin-right: 0.4rem;
+  text-transform: none;
+}
+.page__taxonomy a:hover {
+  background: var(--accent);
+  color: #fff !important;
+}
+
+/* TOC */
+.toc {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+.toc .nav__title {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #fff;
+  font-family: var(--font-display);
+  letter-spacing: -0.01em;
+  border-radius: 0;
+}
+.toc__menu a {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  background-image: none;
+  border-bottom-color: var(--border) !important;
+  transition: color var(--t-fast) var(--ease),
+    background-color var(--t-fast) var(--ease);
+}
+.toc__menu a:hover,
+.toc__menu .active a {
+  color: var(--accent) !important;
+  background: var(--accent-soft) !important;
+}
+
+/* Sidebar / Author profile */
+.sidebar {
+  font-size: 0.95rem;
+}
+.sidebar .author__avatar img {
+  border-radius: 50% !important;
+  border: 3px solid var(--border) !important;
+  max-width: 120px;
+  box-shadow: var(--shadow-md);
+  transition: transform var(--t-base) var(--ease);
+}
+.sidebar .author__avatar img:hover {
+  transform: scale(1.04);
+}
+.author__name {
+  font-family: var(--font-display);
+  color: var(--text);
+}
+.author__bio {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+/* Hide the legacy theme "Follow" pill — we render our own label below. */
+.author__urls-wrapper > button,
+.author__urls-wrapper button.btn,
+.author__urls-wrapper .btn--inverse {
+  display: none !important;
+}
+
+/* Reset the theme's absolute-positioned urls container; we use our own list. */
+.author__urls,
+.author__urls-wrapper .author__urls {
+  position: static !important;
+  display: block !important;
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+}
+
+/* Location line — sits directly under the bio with a subtle map-pin. */
+.author__location {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.4rem;
+  color: var(--text-subtle);
+  font-size: 0.85rem;
+  line-height: 1.3;
+}
+.author__location i,
+.author__location svg {
+  font-size: 0.9rem;
+  color: var(--text-subtle);
+  fill: currentColor;
+  flex-shrink: 0;
+}
+
+/* "Follow me" label — small, uppercase, tracked. */
+.author__follow-label {
+  margin: 1rem 0 0.5rem;
+  color: var(--text-subtle);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+/* Horizontal row of circular icon-only social buttons. */
+.author__socials {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.author__socials li {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.author__socials li::before {
+  display: none;
+}
+.author__social {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  color: var(--text-muted) !important;
+  background-image: none;
+  text-decoration: none;
+  font-size: 0.95rem;
+  line-height: 1;
+  box-shadow: none;
+  transition: transform var(--t-fast) var(--ease),
+    background var(--t-fast) var(--ease),
+    border-color var(--t-fast) var(--ease),
+    color var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease);
+}
+.author__social:hover,
+.author__social:focus-visible {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  border-color: transparent;
+  color: #fff !important;
+  transform: translateY(-2px);
+  box-shadow: 0 8px 18px -8px rgba(99, 102, 241, 0.55);
+  outline: none;
+}
+/* Inline-SVG brand icons (Simple Icons paths, emitted by `_includes/author-profile.html`).
+   Fixed pixel size — no Font Awesome kit dependency. `fill: currentColor` makes the
+   icon inherit `.author__social`'s color in both the resting and hover states. */
+.author__social svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+  color: inherit;
+  display: block;
+  flex-shrink: 0;
+}
+/* Defensive: kept in case anything still emits an <i> for this slot. */
+.author__social i {
+  font-size: 1rem;
+  line-height: 1;
+  color: inherit;
+}
+/* Hide the visible text label — accessible name comes from aria-label/title. */
+.author__social-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Pagination */
+.pagination,
+.pagination--pager {
+  margin-top: 2rem;
+}
+.pagination li a,
+.pagination--pager {
+  border-radius: 999px !important;
+  border: 1px solid var(--border) !important;
+  background: var(--bg-elev) !important;
+  color: var(--text) !important;
+  background-image: none;
+  transition: all var(--t-fast) var(--ease);
+}
+.pagination li a:hover,
+.pagination--pager:hover {
+  background: var(--bg-soft) !important;
+  border-color: var(--border-strong) !important;
+  color: var(--accent) !important;
+}
+.pagination li .current {
+  background: linear-gradient(
+    135deg,
+    var(--accent),
+    var(--accent-strong)
+  ) !important;
+  color: #fff !important;
+  border: 0 !important;
+}
+
+/* Related & comments */
+.page__related-title,
+.page__share-title {
+  font-family: var(--font-display);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.5rem;
+  color: var(--text);
+}
+
+/* -----------------------------------------------------------------------------
+   8. Forms (newsletter, contact, search)
+   -------------------------------------------------------------------------- */
+input[type="text"],
+input[type="email"],
+input[type="search"],
+textarea,
+.form-control {
+  background: var(--bg-elev) !important;
+  color: var(--text) !important;
+  border: 1px solid var(--border-strong) !important;
+  border-radius: var(--radius-md) !important;
+  padding: 0.75rem 1rem !important;
+  font-family: var(--font-sans) !important;
+  font-size: 0.95rem !important;
+  width: 100%;
+  transition: border-color var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease);
+  box-shadow: none;
+}
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="search"]:focus,
+textarea:focus,
+.form-control:focus {
+  outline: none;
+  border-color: var(--accent) !important;
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+
+label {
+  color: var(--text);
+  font-weight: 500;
+  margin-bottom: 0.4rem;
+  display: block;
+}
+
+button[type="submit"],
+input[type="submit"],
+.button {
+  background: linear-gradient(
+    135deg,
+    var(--accent),
+    var(--accent-strong)
+  ) !important;
+  color: #fff !important;
+  border: 0 !important;
+  border-radius: 999px !important;
+  padding: 0.75rem 1.4rem !important;
+  font-weight: 600 !important;
+  font-family: var(--font-sans) !important;
+  cursor: pointer;
+  box-shadow: 0 8px 24px -8px rgba(99, 102, 241, 0.55) !important;
+  transition: transform var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease);
+}
+button[type="submit"]:hover,
+input[type="submit"]:hover,
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px -8px rgba(99, 102, 241, 0.65) !important;
+}
+
+/* =============================================================================
+   Newsletter (iss-newsletter)
+   Self-contained block. All rules use very high specificity (id + class + class)
+   plus !important so the global `input` / `.button` rules cannot reach in.
+   ============================================================================= */
+section.iss-newsletter,
+#mc_embed_signup.iss-newsletter {
+  background: var(--bg-elev) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: var(--radius-lg) !important;
+  box-shadow: var(--shadow-sm) !important;
+  padding: 1.75rem 1.5rem !important;
+  margin: 2rem auto !important;
+  width: 100% !important;
+  max-width: 520px !important;
+  text-align: center !important;
+  font-family: var(--font-sans) !important;
+  position: relative !important;
+  overflow: hidden !important;
+  box-sizing: border-box !important;
+  clear: both !important;
+}
+section.iss-newsletter::before,
+#mc_embed_signup.iss-newsletter::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    560px 240px at 100% 0%,
+    var(--accent-soft),
+    transparent 60%
+  );
+  pointer-events: none;
+}
+section.iss-newsletter .iss-newsletter__inner,
+#mc_embed_signup.iss-newsletter .iss-newsletter__inner {
+  position: relative;
+  z-index: 1;
+}
+section.iss-newsletter .iss-newsletter__title,
+#mc_embed_signup.iss-newsletter .iss-newsletter__title {
+  font-family: var(--font-display) !important;
+  font-weight: 700 !important;
+  font-size: 1.25rem !important;
+  color: var(--text) !important;
+  letter-spacing: -0.01em !important;
+  margin: 0 0 0.4rem !important;
+  line-height: 1.2 !important;
+}
+section.iss-newsletter .iss-newsletter__hint,
+#mc_embed_signup.iss-newsletter .iss-newsletter__hint {
+  color: var(--text-muted) !important;
+  font-size: 0.9rem !important;
+  line-height: 1.5 !important;
+  margin: 0 auto 1.25rem !important;
+  max-width: 380px !important;
+}
+section.iss-newsletter .iss-newsletter__form,
+#mc_embed_signup.iss-newsletter .iss-newsletter__form {
+  display: flex !important;
+  flex-wrap: wrap !important;
+  gap: 0.5rem !important;
+  align-items: stretch !important;
+  justify-content: center !important;
+  margin: 0 auto !important;
+  max-width: 440px !important;
+}
+section.iss-newsletter .iss-newsletter__sr,
+#mc_embed_signup.iss-newsletter .iss-newsletter__sr {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+}
+
+/* Email input — bulletproof override */
+section.iss-newsletter input.iss-newsletter__input,
+#mc_embed_signup.iss-newsletter input.iss-newsletter__input,
+section.iss-newsletter input[type="email"].iss-newsletter__input,
+#mc_embed_signup.iss-newsletter input[type="email"].iss-newsletter__input {
+  flex: 1 1 200px !important;
+  min-width: 0 !important;
+  width: auto !important;
+  height: 46px !important;
+  padding: 0 0.95rem !important;
+  background: var(--bg) !important;
+  color: var(--text) !important;
+  border: 1px solid var(--border-strong) !important;
+  border-radius: 12px !important;
+  font-family: var(--font-sans) !important;
+  font-size: 0.95rem !important;
+  font-weight: 400 !important;
+  line-height: 46px !important;
+  box-shadow: none !important;
+  outline: none !important;
+  margin: 0 !important;
+  text-align: left !important;
+  -webkit-appearance: none !important;
+          appearance: none !important;
+  transition: border-color var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease);
+}
+section.iss-newsletter input.iss-newsletter__input::placeholder,
+#mc_embed_signup.iss-newsletter input.iss-newsletter__input::placeholder {
+  color: var(--text-subtle) !important;
+  opacity: 1 !important;
+}
+section.iss-newsletter input.iss-newsletter__input:focus,
+#mc_embed_signup.iss-newsletter input.iss-newsletter__input:focus {
+  border-color: var(--accent) !important;
+  box-shadow: 0 0 0 4px var(--accent-soft) !important;
+}
+
+/* Submit button — bulletproof override */
+section.iss-newsletter button.iss-newsletter__btn,
+#mc_embed_signup.iss-newsletter button.iss-newsletter__btn,
+section.iss-newsletter input[type="submit"].iss-newsletter__btn,
+#mc_embed_signup.iss-newsletter input[type="submit"].iss-newsletter__btn {
+  flex: 0 0 auto !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  height: 46px !important;
+  min-width: 130px !important;
+  width: auto !important;
+  padding: 0 1.4rem !important;
+  background: linear-gradient(
+    135deg,
+    var(--accent),
+    var(--accent-strong)
+  ) !important;
+  color: #ffffff !important;
+  border: 0 !important;
+  border-radius: 12px !important;
+  font-family: var(--font-sans) !important;
+  font-size: 0.95rem !important;
+  font-weight: 600 !important;
+  line-height: 1 !important;
+  letter-spacing: 0 !important;
+  text-transform: none !important;
+  white-space: nowrap !important;
+  cursor: pointer !important;
+  margin: 0 !important;
+  -webkit-appearance: none !important;
+          appearance: none !important;
+  box-shadow: 0 8px 22px -8px rgba(99, 102, 241, 0.55) !important;
+  transition: transform var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease), filter var(--t-fast) var(--ease);
+  text-shadow: none !important;
+}
+section.iss-newsletter button.iss-newsletter__btn:hover,
+#mc_embed_signup.iss-newsletter button.iss-newsletter__btn:hover {
+  filter: brightness(1.06);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px -8px rgba(99, 102, 241, 0.65) !important;
+}
+section.iss-newsletter button.iss-newsletter__btn:active,
+#mc_embed_signup.iss-newsletter button.iss-newsletter__btn:active {
+  transform: translateY(0);
+}
+
+/* Stack on small screens */
+@media (max-width: 480px) {
+  section.iss-newsletter .iss-newsletter__form,
+  #mc_embed_signup.iss-newsletter .iss-newsletter__form {
+    flex-direction: column !important;
+  }
+  section.iss-newsletter button.iss-newsletter__btn,
+  #mc_embed_signup.iss-newsletter button.iss-newsletter__btn {
+    width: 100% !important;
+  }
+}
+
+/* Sidebar variant — narrow column on /blog/, /visualizations/, single posts.
+   Always stacks vertically, smaller paddings, smaller type. */
+section.iss-newsletter--sidebar,
+#mc_embed_signup.iss-newsletter--sidebar {
+  max-width: 100% !important;
+  margin: 1.5rem 0 !important;
+  padding: 1.1rem 1rem !important;
+  text-align: left !important;
+  border-radius: var(--radius-md) !important;
+}
+section.iss-newsletter--sidebar .iss-newsletter__title,
+#mc_embed_signup.iss-newsletter--sidebar .iss-newsletter__title {
+  font-size: 1.05rem !important;
+  margin: 0 0 0.3rem !important;
+}
+section.iss-newsletter--sidebar .iss-newsletter__hint,
+#mc_embed_signup.iss-newsletter--sidebar .iss-newsletter__hint {
+  font-size: 0.82rem !important;
+  margin: 0 0 0.85rem !important;
+  max-width: none !important;
+  text-align: left !important;
+}
+section.iss-newsletter--sidebar .iss-newsletter__form,
+#mc_embed_signup.iss-newsletter--sidebar .iss-newsletter__form {
+  flex-direction: column !important;
+  align-items: stretch !important;
+  justify-content: flex-start !important;
+  gap: 0.45rem !important;
+  max-width: 100% !important;
+  margin: 0 !important;
+}
+section.iss-newsletter--sidebar input.iss-newsletter__input,
+#mc_embed_signup.iss-newsletter--sidebar input.iss-newsletter__input,
+section.iss-newsletter--sidebar input[type="email"].iss-newsletter__input,
+#mc_embed_signup.iss-newsletter--sidebar input[type="email"].iss-newsletter__input {
+  flex: 0 0 auto !important;
+  width: 100% !important;
+  height: 42px !important;
+  line-height: 42px !important;
+  padding: 0 0.8rem !important;
+  font-size: 0.88rem !important;
+  border-radius: 10px !important;
+}
+section.iss-newsletter--sidebar button.iss-newsletter__btn,
+#mc_embed_signup.iss-newsletter--sidebar button.iss-newsletter__btn {
+  width: 100% !important;
+  height: 42px !important;
+  min-width: 0 !important;
+  padding: 0 1rem !important;
+  font-size: 0.9rem !important;
+  border-radius: 10px !important;
+}
+
+/* -----------------------------------------------------------------------------
+   9. Footer
+   -------------------------------------------------------------------------- */
+.page__footer {
+  margin-top: 4rem;
+  background: var(--bg-elev) !important;
+  color: var(--text) !important;
+  border-top: 1px solid var(--border);
+  padding: 2.5rem 1.5rem 2rem;
+}
+.page__footer-follow {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+.page__footer-follow .social-icons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.page__footer-follow .social-icons li {
+  list-style: none;
+}
+.page__footer-follow .social-icons strong {
+  color: var(--text-muted);
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-right: 0.75rem;
+}
+.page__footer-follow .social-icons a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--bg-soft);
+  color: var(--text-muted) !important;
+  border-radius: 999px;
+  padding: 0.45rem 0.85rem;
+  font-size: 0.85rem;
+  background-image: none;
+  border: 1px solid var(--border);
+  transition: all var(--t-fast) var(--ease);
+}
+.page__footer-follow .social-icons a:hover {
+  background: var(--accent);
+  color: #fff !important;
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+.page__footer-follow .social-icons a svg {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.page__footer-copyright {
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+  border-top: 1px solid var(--border);
+  padding-top: 1.25rem;
+}
+.page__footer-copyright p {
+  max-width: 640px;
+  margin: 0.65rem auto 0;
+  line-height: 1.55;
+}
+.page__footer-copyright a {
+  color: var(--text-muted);
+  background-image: none;
+}
+.page__footer-copyright a:hover {
+  color: var(--accent);
+}
+.page__footer-cc-badge {
+  display: inline-block;
+  background-image: none;
+}
+.page__footer-cc-badge img {
+  display: inline-block;
+  border: 0;
+  border-radius: 4px;
+  background: #fff;
+  padding: 2px;
+  vertical-align: middle;
+  transition: transform var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease);
+}
+.page__footer-cc-badge:hover img {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+/* -----------------------------------------------------------------------------
+   10. Misc fixes — overrides for theme defaults that clash with the new look
+   -------------------------------------------------------------------------- */
+/* Page wrapper backgrounds & widths */
+#main {
+  max-width: var(--container-max);
+  padding: 1.5rem 1.25rem;
+}
+
+.page__hero--overlay + .initial-content #main,
+.page__hero--overlay + #main {
+  padding-top: 2rem;
+}
+
+.greedy-nav .hidden-links {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-md);
+  border-radius: var(--radius-md);
+  padding: 0.5rem;
+}
+.greedy-nav .hidden-links li a {
+  color: var(--text-muted) !important;
+  border-radius: var(--radius-sm);
+}
+.greedy-nav .hidden-links::before,
+.greedy-nav .hidden-links::after {
+  display: none;
+}
+
+/* Algolia search overlay tweaks */
+.ais-SearchBox-input {
+  background: var(--bg-elev) !important;
+  color: var(--text) !important;
+}
+
+/* Splash layout (homepage) */
+.layout--splash .page__hero--overlay {
+  margin-bottom: 0;
+}
+
+/* Section headings on the homepage — give them a small accent bar */
+.layout--splash #main > h1 {
+  position: relative;
+  font-size: #{"clamp(1.6rem, 1.2rem + 1.5vw, 2.25rem)"};
+  margin-top: 3rem;
+  padding-top: 0.5rem;
+}
+.layout--splash #main > h1::before {
+  content: "";
+  display: block;
+  width: 44px;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  margin-bottom: 0.9rem;
+}
+
+/* Whoami CV tables — soft borders so the rowspan layout still reads,
+   without the heavy theme defaults. */
+.layout--single .page__content table {
+  background: transparent;
+  box-shadow: none;
+  border: 0;
+  border-radius: 0;
+  overflow: visible;
+}
+.layout--single .page__content table td {
+  border: 0 !important;
+  border-bottom: 1px solid var(--border) !important;
+  background: transparent;
+  vertical-align: top;
+  padding: 0.85rem 0.75rem;
+}
+.layout--single .page__content table tr:last-child td {
+  border-bottom: 0 !important;
+}
+.layout--single .page__content table thead {
+  background: transparent;
+}
+.layout--single .page__content table img {
+  border-radius: var(--radius-sm);
+  background: var(--bg-soft);
+  padding: 0.25rem;
+}
+
+/* Whoami chip-style buttons should not look like CTAs */
+.layout--single .page__content a.btn.btn--inverse {
+  padding: 0.25rem 0.65rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  color: var(--text-muted) !important;
+  box-shadow: none;
+  margin: 0.15rem 0.2rem 0.15rem 0;
+}
+
+/* 404 — Not Found page */
+.not-found {
+  max-width: 720px;
+  margin: 4rem auto;
+  text-align: center;
+  padding: 0 1.25rem;
+}
+.not-found__digits {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: #{"clamp(6rem, 5rem + 8vw, 12rem)"};
+  line-height: 0.95;
+  letter-spacing: -0.06em;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 1rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+.not-found__zero {
+  display: inline-block;
+  animation: notFoundSpin 8s linear infinite;
+  transform-origin: 50% 55%;
+}
+@keyframes notFoundSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.not-found__title {
+  font-family: var(--font-display);
+  font-size: #{"clamp(1.6rem, 1.2rem + 1.5vw, 2.5rem)"};
+  margin: 0 0 0.75rem;
+  color: var(--text);
+}
+.not-found__lead {
+  color: var(--text-muted);
+  font-size: 1.1rem;
+  line-height: 1.6;
+  margin: 0 auto 2rem;
+  max-width: 540px;
+}
+.not-found__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  justify-content: center;
+  margin-bottom: 2.5rem;
+}
+.not-found__suggest {
+  border-top: 1px solid var(--border);
+  padding-top: 1.5rem;
+  margin-top: 1rem;
+}
+.not-found__suggest-title {
+  color: var(--text-subtle);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.75rem;
+}
+.not-found__suggest ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+}
+.not-found__suggest li {
+  list-style: none;
+}
+.not-found__suggest a {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  background: var(--bg-soft);
+  color: var(--text-muted) !important;
+  border: 1px solid var(--border);
+  font-size: 0.9rem;
+  background-image: none;
+  transition: all var(--t-fast) var(--ease);
+}
+.not-found__suggest a:hover {
+  background: var(--accent);
+  color: #fff !important;
+  border-color: var(--accent);
+}
+
+/* Social pill row (used on /whoami/) */
+.social-pill-row {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.social-pill-row li {
+  list-style: none;
+  margin: 0;
+}
+.social-pill-row a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.95rem;
+  border-radius: 999px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  color: var(--text-muted) !important;
+  font-size: 0.9rem;
+  font-weight: 500;
+  background-image: none;
+  text-decoration: none;
+  transition: all var(--t-fast) var(--ease);
+}
+.social-pill-row a:hover {
+  background: var(--accent);
+  color: #fff !important;
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 18px -8px rgba(99, 102, 241, 0.55);
+}
+.social-pill-row a i {
+  font-size: 1rem;
+}
+/* Inline SVG variant — used in place of the FA <i> when the kit is unavailable.
+   Inherits color from the parent <a> via fill="currentColor", so the hover
+   state (white on accent background) just works. */
+.social-pill-row a svg,
+.social-pill-row svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+  flex-shrink: 0;
+  vertical-align: middle;
+}
+
+/* Reveal-on-scroll animation */
+.reveal {
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 0.6s var(--ease), transform 0.6s var(--ease);
+  will-change: opacity, transform;
+}
+.reveal.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Skip-link */
+.skip-link {
+  background: var(--accent);
+  color: #fff;
+}
+
+/* Comments (Disqus) — give it a card */
+#disqus_thread {
+  margin-top: 2rem;
+  padding: 1.25rem;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+/* Make the masthead spacing breathe on small screens */
+@media (max-width: 720px) {
+  .greedy-nav .site-title {
+    font-size: 1.05rem;
+  }
+  .masthead__inner-wrap {
+    padding: 0.5rem 0.9rem;
+  }
+  #main {
+    padding: 1rem 0.9rem;
+  }
+}
+
+/* =============================================================================
+   11. Tips listing — vertical list of cards (entries_layout: list)
+   Scoped under `.entries-list` so these styles only apply on pages that opt
+   into Minimal Mistakes' list layout (currently /tips/). They do NOT touch
+   `.grid__*` cards on /blog/ and /visualizations/, nor the search-results
+   template which also emits bare `<div class="list__item">` markup.
+   ============================================================================= */
+.entries-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 820px;
+  margin: 0;
+}
+
+.entries-list .list__item {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  float: none;
+}
+
+.entries-list .list__item .archive__item {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 1rem 1.25rem;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--t-base) var(--ease),
+    box-shadow var(--t-base) var(--ease),
+    border-color var(--t-base) var(--ease);
+}
+.entries-list .list__item .archive__item:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+  border-color: var(--border-strong);
+}
+
+/* Tip cards have no teaser; hide defensively if the theme ever emits one. */
+.entries-list .list__item .archive__item-teaser {
+  display: none;
+}
+
+.entries-list .list__item .archive__item-title {
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  margin: 0;
+  padding-right: 3.5rem; /* leaves room for the "Tip" chip */
+}
+.entries-list .list__item .archive__item-title a {
+  color: var(--text);
+  background-image: none;
+  transition: color var(--t-fast) var(--ease);
+}
+.entries-list .list__item .archive__item-title a:hover {
+  color: var(--accent);
+}
+
+/* Meta line — clock icon + read time, in a subtle color. */
+.entries-list .list__item .archive__item .page__meta,
+.entries-list .list__item .archive__item .page__date {
+  margin: 0;
+  color: var(--text-subtle);
+  font-size: 0.82rem;
+  line-height: 1.3;
+}
+.entries-list .list__item .archive__item .page__meta i {
+  margin-right: 0.3rem;
+  color: var(--text-subtle);
+}
+
+.entries-list .list__item .archive__item-excerpt {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.93rem;
+  line-height: 1.55;
+}
+.entries-list .list__item .archive__item-excerpt p {
+  margin: 0;
+}
+
+/* Small "Tip" chip anchored to the top-right of each card. */
+.entries-list .list__item .archive__item::before {
+  content: "Tip";
+  position: absolute;
+  top: 0.85rem;
+  right: 1rem;
+  padding: 0.15rem 0.6rem;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  border-radius: 999px;
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  pointer-events: none;
+}
+
+@media (max-width: 520px) {
+  .entries-list .list__item .archive__item {
+    padding: 0.9rem 1rem;
+  }
+  .entries-list .list__item .archive__item-title {
+    font-size: 1.05rem;
+    padding-right: 3rem;
+  }
+  .entries-list .list__item .archive__item::before {
+    top: 0.75rem;
+    right: 0.75rem;
+  }
+}
+
+/* =============================================================================
+   12. Feature row — equal-height cards with bottom-pinned CTAs
+   Appended override block. The grid above stretches each `.feature__item`
+   to the row's tallest height (default `align-items: stretch`), but the
+   inner `.archive__item` doesn't fill that height, so cards in the same
+   row end with their CTA buttons at uneven vertical positions.
+
+   Fix:
+   - Force `.archive__item` (and the --left/--right/--center variants) to
+     `height: 100%` so they fill the stretched grid item.
+   - Inside `.archive__item-body`, pin the trailing CTA paragraph to the
+     bottom via `margin-top: auto` so excerpts of different lengths
+     don't shift the buttons. The CTA is rendered as a final
+     `<p><a class="btn ...">…</a></p>` direct child of
+     `.archive__item-body`, so `> p:last-child` is a reliable target.
+   - Selectors are scoped under `.feature__wrapper` so the affected
+     scope matches the homepage rows (and the same wrapper on the
+     "What's here" section), without leaking into other components.
+
+   Zig-zag neutralizer:
+   The upstream theme renders `.feature__item--left/--right/--center` as a
+   magazine-style staggered layout: each item is floated, alternating
+   `nth-child` siblings get `margin-left: gutter(of 12)`, and inside each
+   card the `.archive__item-teaser` is `float: left; width: 5/12` while the
+   `.archive__item-body` is `float: right; width: 7/12`. Inside our CSS
+   Grid this manifests as cards offset horizontally and split internally —
+   the visible zig-zag. The block below forces every variant (and its
+   inner pieces) back to a clean, full-width, non-floated layout so the
+   grid alone controls placement. `!important` is used because several
+   upstream rules use `nth-child` at specificity 0,2,0 which our base
+   selectors cannot beat without it.
+   ============================================================================= */
+.feature__wrapper .feature__item,
+.feature__wrapper .feature__item--left,
+.feature__wrapper .feature__item--right,
+.feature__wrapper .feature__item--center {
+  align-self: stretch;
+  float: none !important;
+  clear: none !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+  width: auto !important;
+  padding: 0 !important;
+}
+
+.feature__wrapper .feature__item .archive__item,
+.feature__wrapper .feature__item--left .archive__item,
+.feature__wrapper .feature__item--right .archive__item,
+.feature__wrapper .feature__item--center .archive__item {
+  float: none !important;
+  width: 100% !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.feature__wrapper .feature__item .archive__item-teaser,
+.feature__wrapper .feature__item--left .archive__item-teaser,
+.feature__wrapper .feature__item--right .archive__item-teaser,
+.feature__wrapper .feature__item--center .archive__item-teaser {
+  float: none !important;
+  width: 100% !important;
+  max-width: none !important;
+  margin: 0 !important;
+}
+
+.feature__wrapper .feature__item .archive__item-body,
+.feature__wrapper .feature__item--left .archive__item-body,
+.feature__wrapper .feature__item--right .archive__item-body,
+.feature__wrapper .feature__item--center .archive__item-body {
+  float: none !important;
+  width: 100% !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.feature__wrapper .feature__item .archive__item,
+.feature__wrapper .feature__item--left .archive__item,
+.feature__wrapper .feature__item--right .archive__item,
+.feature__wrapper .feature__item--center .archive__item {
+  height: 100%;
+}
+
+.feature__wrapper .feature__item .archive__item-body,
+.feature__wrapper .feature__item--left .archive__item-body,
+.feature__wrapper .feature__item--right .archive__item-body,
+.feature__wrapper .feature__item--center .archive__item-body {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+}
+
+.feature__wrapper .feature__item .archive__item-body .archive__item-title,
+.feature__wrapper .feature__item--left .archive__item-body .archive__item-title,
+.feature__wrapper .feature__item--right .archive__item-body .archive__item-title,
+.feature__wrapper .feature__item--center .archive__item-body .archive__item-title {
+  flex: 0 0 auto;
+}
+
+.feature__wrapper .feature__item .archive__item-body .archive__item-excerpt,
+.feature__wrapper .feature__item--left .archive__item-body .archive__item-excerpt,
+.feature__wrapper .feature__item--right .archive__item-body .archive__item-excerpt,
+.feature__wrapper .feature__item--center .archive__item-body .archive__item-excerpt {
+  flex: 1 1 auto;
+}
+
+/* Pin the trailing CTA paragraph to the bottom of the card body. */
+.feature__wrapper .feature__item .archive__item-body > p:last-child,
+.feature__wrapper .feature__item--left .archive__item-body > p:last-child,
+.feature__wrapper .feature__item--right .archive__item-body > p:last-child,
+.feature__wrapper .feature__item--center .archive__item-body > p:last-child {
+  margin-top: auto;
+  margin-bottom: 0;
+}
+
+/* =============================================================================
+   14. CV meta icons — small inline FA icons used inside `/whoami/` CV tables
+   for role / company / dates / location (and accomplishment stars). Each
+   `<li class="cv-meta">` wraps a Font Awesome `<i>` plus a `<span>` with the
+   actual text, so the icon is theme-aware (uses `var(--accent)` instead of a
+   PNG that picks up the global table-image background chip), crisp at any
+   size, and the icon column stays aligned across rows.
+   Scoped tightly to `.cv-meta` so it can't reach into the company-logo
+   `<img>` tags (those keep the soft background chip from rule 10).
+   ============================================================================= */
+.cv-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin: 0;
+  list-style: none;
+}
+.cv-meta::before {
+  display: none;
+}
+.cv-meta i {
+  width: 16px;
+  flex: 0 0 auto;
+  color: var(--accent);
+  font-size: 0.9rem;
+  text-align: center;
+  position: relative;
+  top: 1px;
+}
+/* Inline SVG variant — replaces the FA <i> when the kit is unavailable.
+   Inherits color via fill="currentColor" from the explicit `color` set here. */
+.cv-meta svg {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  flex-shrink: 0;
+  color: var(--accent);
+  fill: currentColor;
+  position: relative;
+  top: 2px;
+}
+.cv-meta strong {
+  font-weight: 600;
+  color: var(--text);
+}
+.cv-meta span,
+.cv-meta a {
+  color: var(--text-muted);
+}
+.cv-meta a:hover {
+  color: var(--accent);
+}
+
+/* =============================================================================
+   15. Code blocks — copy button + language label
+   Targeted enhancements for Rouge / Kramdown code blocks. The header bar is
+   injected at runtime by `initCodeCopy()` in assets/js/custom/modern.js, which
+   adds the `.has-copy-btn` marker class so these rules can out-specify the
+   generic `pre, div.highlighter-rouge, figure.highlight` block above without
+   `!important`.
+
+   Rendered DOM:
+     <div class="language-python highlighter-rouge has-copy-btn">
+       <div class="code-block-header">
+         <span class="code-block-lang">Python</span>
+         <button class="code-copy-btn" type="button" ...>
+           <svg class="icon-copy">…</svg>
+           <svg class="icon-check">…</svg>
+           <span class="sr-only">Copy code</span>
+         </button>
+       </div>
+       <div class="highlight"><pre class="highlight"><code>…</code></pre></div>
+     </div>
+
+   `figure.highlight` (used by `{% highlight %}` blocks) follows the same
+   structure with `figure.highlight.has-copy-btn > .code-block-header + pre`.
+   ============================================================================= */
+div.highlighter-rouge.has-copy-btn,
+figure.highlight.has-copy-btn {
+  position: relative;
+  margin: 1.5rem 0;
+  padding: 0;
+  overflow: hidden;
+  background: var(--code-bg);
+  border: 1px solid var(--code-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--t-base) var(--ease),
+    border-color var(--t-base) var(--ease),
+    transform var(--t-base) var(--ease);
+}
+
+div.highlighter-rouge.has-copy-btn:hover,
+figure.highlight.has-copy-btn:hover {
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-1px);
+}
+
+/* Subtle gradient hairline along the very top of the block. */
+div.highlighter-rouge.has-copy-btn::before,
+figure.highlight.has-copy-btn::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--accent-soft),
+    transparent
+  );
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* Header bar — language label (left) + copy button (right). */
+div.highlighter-rouge.has-copy-btn > .code-block-header,
+figure.highlight.has-copy-btn > .code-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.45rem 0.75rem 0.45rem 1.05rem;
+  border-bottom: 1px solid var(--code-border);
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.02),
+    transparent
+  );
+  font-family: var(--font-sans);
+  user-select: none;
+}
+
+[data-theme="dark"] div.highlighter-rouge.has-copy-btn > .code-block-header,
+[data-theme="dark"] figure.highlight.has-copy-btn > .code-block-header {
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.025),
+    transparent
+  );
+}
+
+.code-block-lang {
+  display: inline-block;
+  color: var(--text-subtle);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  line-height: 1.4;
+}
+
+.code-copy-btn {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.55rem;
+  width: auto;
+  min-width: 32px;
+  height: 28px;
+  background: var(--bg-elev);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: none;
+  transition: background-color var(--t-fast) var(--ease),
+    color var(--t-fast) var(--ease),
+    border-color var(--t-fast) var(--ease),
+    transform var(--t-fast) var(--ease);
+}
+
+.code-copy-btn:hover {
+  background: var(--bg-soft);
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+
+.code-copy-btn:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.code-copy-btn:active {
+  transform: translateY(1px);
+}
+
+.code-copy-btn svg {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* Toggle the two icons via the `is-copied` state class. */
+.code-copy-btn .icon-check {
+  display: none;
+}
+.code-copy-btn.is-copied .icon-copy,
+.code-copy-btn.is-error .icon-copy {
+  display: none;
+}
+.code-copy-btn.is-copied .icon-check {
+  display: inline-block;
+}
+
+/* Success state — green pill. */
+.code-copy-btn.is-copied {
+  background: linear-gradient(135deg, #10b981, #059669);
+  color: #ffffff;
+  border-color: transparent;
+}
+
+/* Error state — red pill. */
+.code-copy-btn.is-error {
+  background: linear-gradient(135deg, #ef4444, #dc2626);
+  color: #ffffff;
+  border-color: transparent;
+}
+
+/* Visually-hidden screen-reader label inside the button. */
+.code-copy-btn .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Inner code body — neutralize the base `pre, div.highlighter-rouge,
+   figure.highlight` rule for outer chrome (we draw it on the wrapper) and
+   tighten the typography of the actual code. */
+div.highlighter-rouge.has-copy-btn > .highlight,
+figure.highlight.has-copy-btn > pre,
+figure.highlight.has-copy-btn > .highlight {
+  margin: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+div.highlighter-rouge.has-copy-btn pre,
+div.highlighter-rouge.has-copy-btn pre.highlight,
+figure.highlight.has-copy-btn pre,
+figure.highlight.has-copy-btn pre.highlight {
+  margin: 0;
+  padding: 1rem 1.1rem;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  font-family: var(--font-mono);
+  font-size: 0.86rem;
+  line-height: 1.6;
+  overflow-x: auto;
+  color: var(--code-text);
+}
+
+div.highlighter-rouge.has-copy-btn pre code,
+figure.highlight.has-copy-btn pre code {
+  display: block;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  color: inherit;
+}
+
+/* Rouge line-numbers table layout (when used) — remove inner padding so the
+   parent `pre` controls spacing uniformly. */
+div.highlighter-rouge.has-copy-btn table.rouge-table,
+figure.highlight.has-copy-btn table.rouge-table {
+  margin: 0;
+  border: 0;
+  background: transparent;
+  border-radius: 0;
+  box-shadow: none;
+}
+div.highlighter-rouge.has-copy-btn table.rouge-table td,
+figure.highlight.has-copy-btn table.rouge-table td {
+  border: 0 !important;
+  padding: 0 0.5rem;
+  background: transparent;
+}
+div.highlighter-rouge.has-copy-btn td.rouge-gutter,
+div.highlighter-rouge.has-copy-btn td.gutter,
+figure.highlight.has-copy-btn td.rouge-gutter,
+figure.highlight.has-copy-btn td.gutter {
+  color: var(--text-subtle);
+  border-right: 1px solid var(--code-border) !important;
+  padding-right: 0.75rem !important;
+}
+
+/* Make the line-number gutter unselectable, so manual Cmd/Ctrl+C selections
+   yield clean code without numeric prefixes. Also prevents the gutter from
+   sneaking into copy paths that fall back to a wider element's text. */
+.rouge-table .rouge-gutter,
+.rouge-table .rouge-gutter pre,
+.rouge-table .gutter,
+.rouge-table .gutter pre,
+.rouge-table .gl,
+.rouge-table .lineno {
+  user-select: none !important;
+  -webkit-user-select: none !important;
+  -moz-user-select: none !important;
+}
+
+/* Dark-mode token color boosts — Rouge ships a Pygments-style palette that
+   can lose contrast on the deep `--code-bg` (#0d1230). These overrides nudge
+   a handful of common tokens toward higher-contrast hues without rewriting
+   the full theme. */
+[data-theme="dark"] .highlight .c,
+[data-theme="dark"] .highlight .c1,
+[data-theme="dark"] .highlight .cm,
+[data-theme="dark"] .highlight .cs,
+[data-theme="dark"] .highlight .cp {
+  color: #8a93ab;
+  font-style: italic;
+}
+[data-theme="dark"] .highlight .k,
+[data-theme="dark"] .highlight .kd,
+[data-theme="dark"] .highlight .kn,
+[data-theme="dark"] .highlight .kp,
+[data-theme="dark"] .highlight .kr,
+[data-theme="dark"] .highlight .kt {
+  color: #f472b6;
+  font-weight: 600;
+}
+[data-theme="dark"] .highlight .nf,
+[data-theme="dark"] .highlight .nc,
+[data-theme="dark"] .highlight .nb {
+  color: #a5b4fc;
+}
+[data-theme="dark"] .highlight .nn,
+[data-theme="dark"] .highlight .nd {
+  color: #c4b5fd;
+}
+[data-theme="dark"] .highlight .s,
+[data-theme="dark"] .highlight .s1,
+[data-theme="dark"] .highlight .s2,
+[data-theme="dark"] .highlight .se,
+[data-theme="dark"] .highlight .sb,
+[data-theme="dark"] .highlight .sr {
+  color: #6ee7b7;
+}
+[data-theme="dark"] .highlight .mi,
+[data-theme="dark"] .highlight .mf,
+[data-theme="dark"] .highlight .mh,
+[data-theme="dark"] .highlight .mo,
+[data-theme="dark"] .highlight .il {
+  color: #fbbf24;
+}
+[data-theme="dark"] .highlight .o,
+[data-theme="dark"] .highlight .ow {
+  color: #e7ecf5;
+}
+[data-theme="dark"] .highlight .na,
+[data-theme="dark"] .highlight .nv,
+[data-theme="dark"] .highlight .vi,
+[data-theme="dark"] .highlight .vg {
+  color: #93c5fd;
+}
+[data-theme="dark"] .highlight .err {
+  color: #fca5a5;
+  background: transparent;
+}
+
+@media (max-width: 520px) {
+  div.highlighter-rouge.has-copy-btn > .code-block-header,
+  figure.highlight.has-copy-btn > .code-block-header {
+    padding: 0.4rem 0.55rem 0.4rem 0.85rem;
+  }
+  div.highlighter-rouge.has-copy-btn pre,
+  figure.highlight.has-copy-btn pre {
+    padding: 0.85rem 0.95rem;
+    font-size: 0.82rem;
+  }
+}
+
+/* =============================================================================
+   16. Social-share buttons (`_includes/social-share.html`)
+   The share section at the bottom of every blog post emits a row of brand
+   buttons (X / Facebook / LinkedIn / Bluesky). Each button used to wrap a
+   Font Awesome `<i class="fab fa-...">` glyph; we now render an inline
+   Simple Icons SVG instead so the icons survive without the FA kit.
+   `fill: currentColor` makes the SVG inherit the button's text color,
+   so the brand-tinted button backgrounds (or the default `.btn` style)
+   continue to drive contrast in both light and dark themes.
+   ============================================================================= */
+.page__share .btn svg {
+  width: 1em;
+  height: 1em;
+  vertical-align: -0.15em;
+  margin-right: 0.4em;
+  fill: currentColor;
+  flex-shrink: 0;
+}
+
+/* =============================================================================
+   17. Heading anchor link (chain) icon
+   Minimal Mistakes' `main.min.js` appends a `.header-link` anchor inside
+   every `.page__content` heading. We swap the legacy "Permalink" text +
+   Font Awesome glyph for an inline SVG chain icon at runtime
+   (`assets/js/custom/modern.js` → `initHeaderLinkIcon`). The base
+   `.header-link` opacity / hover behaviour comes from
+   `_sass/minimal-mistakes/_page.scss`; the rules below just size, align
+   and color the new SVG and visually hide the screen-reader label.
+   ============================================================================= */
+.page__content .header-link {
+  text-decoration: none;
+  color: var(--text-muted);
+  line-height: 1;
+}
+
+.page__content .header-link:hover,
+.page__content .header-link:focus-visible {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.page__content .header-link .icon-link {
+  width: 0.85em;
+  height: 0.85em;
+  vertical-align: -0.1em;
+  fill: none;
+  stroke: currentColor;
+}
+
+/* Visually hide the "Permalink" sr-only label (the project doesn't define
+   `.sr-only` globally; we scope the helper to header-links to avoid
+   colliding with anywhere else the class might appear). */
+.page__content .header-link .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* =============================================================================
+   18. Contact form (iss-contact)
+   Self-contained card form for `/contactme/`. Mirrors the iss-newsletter
+   visual language (card surface, gradient halo, gradient pill submit button)
+   but adapted for a vertical, multi-field layout. All selectors use very high
+   specificity (`section.iss-contact <type>.iss-contact__<el>`) plus
+   `!important` so the global form rules in section 8 cannot reach in.
+   ============================================================================= */
+section.iss-contact {
+  background: var(--bg-elev) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: var(--radius-lg) !important;
+  box-shadow: var(--shadow-sm) !important;
+  padding: 2rem 1.75rem !important;
+  margin: 2rem auto !important;
+  width: 100% !important;
+  max-width: 640px !important;
+  font-family: var(--font-sans) !important;
+  position: relative !important;
+  overflow: hidden !important;
+  box-sizing: border-box !important;
+  clear: both !important;
+}
+section.iss-contact::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    640px 280px at 100% 0%,
+    var(--accent-soft),
+    transparent 60%
+  );
+  pointer-events: none;
+}
+section.iss-contact .iss-contact__inner {
+  position: relative;
+  z-index: 1;
+}
+section.iss-contact .iss-contact__title {
+  font-family: var(--font-display) !important;
+  font-weight: 700 !important;
+  font-size: 1.6rem !important;
+  color: var(--text) !important;
+  letter-spacing: -0.01em !important;
+  margin: 0 0 0.5rem !important;
+  line-height: 1.2 !important;
+}
+section.iss-contact .iss-contact__hint {
+  color: var(--text-muted) !important;
+  font-size: 0.95rem !important;
+  line-height: 1.55 !important;
+  margin: 0 0 1.5rem !important;
+}
+
+section.iss-contact .iss-contact__form {
+  display: block !important;
+  margin: 0 !important;
+}
+
+section.iss-contact .iss-contact__field {
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 0.4rem !important;
+  margin-bottom: 1rem !important;
+}
+
+section.iss-contact label.iss-contact__label,
+section.iss-contact .iss-contact__field label {
+  font-family: var(--font-sans) !important;
+  font-size: 0.85rem !important;
+  font-weight: 500 !important;
+  color: var(--text-muted) !important;
+  margin: 0 !important;
+  display: block !important;
+}
+section.iss-contact .iss-contact__optional {
+  color: var(--text-subtle) !important;
+  font-weight: 400 !important;
+}
+
+/* Text inputs — bulletproof override */
+section.iss-contact input.iss-contact__input,
+section.iss-contact input[type="text"].iss-contact__input,
+section.iss-contact input[type="email"].iss-contact__input {
+  width: 100% !important;
+  height: 46px !important;
+  padding: 0 0.9rem !important;
+  background: var(--bg-soft) !important;
+  color: var(--text) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: var(--radius-md) !important;
+  font-family: var(--font-sans) !important;
+  font-size: 0.95rem !important;
+  font-weight: 400 !important;
+  line-height: 46px !important;
+  box-shadow: none !important;
+  outline: none !important;
+  margin: 0 !important;
+  -webkit-appearance: none !important;
+          appearance: none !important;
+  transition: border-color var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease),
+    background-color var(--t-fast) var(--ease);
+}
+
+/* Textarea — bulletproof override */
+section.iss-contact textarea.iss-contact__textarea {
+  width: 100% !important;
+  min-height: 140px !important;
+  padding: 0.75rem 0.9rem !important;
+  background: var(--bg-soft) !important;
+  color: var(--text) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: var(--radius-md) !important;
+  font-family: var(--font-sans) !important;
+  font-size: 0.95rem !important;
+  font-weight: 400 !important;
+  line-height: 1.55 !important;
+  box-shadow: none !important;
+  outline: none !important;
+  margin: 0 !important;
+  resize: vertical !important;
+  -webkit-appearance: none !important;
+          appearance: none !important;
+  transition: border-color var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease),
+    background-color var(--t-fast) var(--ease);
+}
+
+section.iss-contact input.iss-contact__input::placeholder,
+section.iss-contact textarea.iss-contact__textarea::placeholder {
+  color: var(--text-subtle) !important;
+  opacity: 1 !important;
+}
+
+section.iss-contact input.iss-contact__input:focus,
+section.iss-contact textarea.iss-contact__textarea:focus {
+  border-color: var(--accent) !important;
+  background: var(--bg) !important;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2) !important;
+}
+[data-theme="dark"] section.iss-contact input.iss-contact__input:focus,
+[data-theme="dark"] section.iss-contact textarea.iss-contact__textarea:focus {
+  box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.28) !important;
+}
+
+section.iss-contact .iss-contact__recaptcha {
+  margin: 0.25rem 0 1.25rem !important;
+}
+
+section.iss-contact .iss-contact__actions {
+  display: flex !important;
+  justify-content: flex-end !important;
+  margin-top: 0.25rem !important;
+}
+
+/* Submit button — gradient pill, mirrors `.iss-newsletter__btn`. */
+section.iss-contact button.iss-contact__btn,
+section.iss-contact input[type="submit"].iss-contact__btn {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  height: 46px !important;
+  min-width: 160px !important;
+  width: auto !important;
+  padding: 0 1.6rem !important;
+  background: linear-gradient(
+    135deg,
+    var(--accent),
+    var(--accent-strong)
+  ) !important;
+  color: #ffffff !important;
+  border: 0 !important;
+  border-radius: 999px !important;
+  font-family: var(--font-sans) !important;
+  font-size: 0.95rem !important;
+  font-weight: 600 !important;
+  line-height: 1 !important;
+  letter-spacing: 0 !important;
+  text-transform: none !important;
+  white-space: nowrap !important;
+  cursor: pointer !important;
+  margin: 0 !important;
+  -webkit-appearance: none !important;
+          appearance: none !important;
+  box-shadow: 0 8px 22px -8px rgba(99, 102, 241, 0.55) !important;
+  transition: transform var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease),
+    filter var(--t-fast) var(--ease);
+  text-shadow: none !important;
+}
+section.iss-contact button.iss-contact__btn:hover {
+  filter: brightness(1.06);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px -8px rgba(99, 102, 241, 0.65) !important;
+}
+section.iss-contact button.iss-contact__btn:active {
+  transform: translateY(0);
+}
+
+/* Mobile — tighter card, full-width submit. */
+@media (max-width: 600px) {
+  section.iss-contact {
+    padding: 1.5rem 1.15rem !important;
+    border-radius: var(--radius-md) !important;
+  }
+  section.iss-contact .iss-contact__title {
+    font-size: 1.35rem !important;
+  }
+  section.iss-contact .iss-contact__actions {
+    justify-content: stretch !important;
+  }
+  section.iss-contact button.iss-contact__btn {
+    width: 100% !important;
+    min-width: 0 !important;
+  }
+}
+
+/* ============================================================
+   19. Tag archive page (/tags/)
+   Renders a tag cloud at the top followed by an anchored
+   section per tag listing the posts that carry it.
+   ============================================================ */
+
+.iss-tag-cloud {
+  margin: 2rem 0 3rem;
+  padding: 1.75rem 1.5rem;
+  background: var(--bg-elev, var(--bg-soft));
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.iss-tag-cloud__title {
+  margin: 0 0 1rem;
+  font-family: var(--font-display, var(--font-sans));
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.iss-tag-cloud__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.iss-tag-cloud__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background-color 160ms ease, border-color 160ms ease,
+    color 160ms ease, transform 160ms ease;
+}
+
+.iss-tag-cloud__chip:hover,
+.iss-tag-cloud__chip:focus-visible {
+  background: var(--accent, #6366f1);
+  border-color: var(--accent, #6366f1);
+  color: #fff;
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+.iss-tag-cloud__chip-count {
+  display: inline-block;
+  min-width: 1.5em;
+  padding: 0 0.4em;
+  border-radius: 999px;
+  background: var(--bg-soft);
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.iss-tag-cloud__chip:hover .iss-tag-cloud__chip-count,
+.iss-tag-cloud__chip:focus-visible .iss-tag-cloud__chip-count {
+  background: rgba(255, 255, 255, 0.22);
+  color: #fff;
+}
+
+.iss-tag-section {
+  margin: 2.5rem 0;
+  padding-top: 1rem;
+  scroll-margin-top: 5rem;
+}
+
+.iss-tag-section__title {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin: 0 0 1rem;
+  font-family: var(--font-display, var(--font-sans));
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.iss-tag-section__hash {
+  color: var(--accent, #6366f1);
+  font-weight: 800;
+}
+
+.iss-tag-section__count {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: var(--bg-soft);
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+}
+
+.iss-tag-section__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.iss-tag-section__item { margin: 0; }
+
+.iss-tag-section__link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 1rem 1.1rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text);
+  text-decoration: none;
+  transition: border-color 160ms ease, transform 160ms ease,
+    box-shadow 160ms ease;
+  height: 100%;
+}
+
+.iss-tag-section__link:hover,
+.iss-tag-section__link:focus-visible {
+  border-color: var(--accent, #6366f1);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-sm);
+  text-decoration: none;
+}
+
+.iss-tag-section__post-title {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--text);
+}
+
+.iss-tag-section__post-excerpt {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.iss-tag-section__post-meta {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-top: auto;
+}
+
+.iss-tag-section__collection { text-transform: capitalize; }
+
+.iss-tag-section__back {
+  display: inline-block;
+  margin-top: 1rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.iss-tag-section__back:hover { color: var(--accent, #6366f1); }
+
+/* -----------------------------------------------------------------------------
+   20. Algolia search overlay
+   The search panel (revealed by the masthead magnifying-glass button) is
+   driven by InstantSearch.js v2.3.3, which renders the input as
+   `.ais-search-box--input` with two absolutely positioned icon buttons:
+   `.ais-search-box--magnifier-wrapper` on the left and
+   `.ais-search-box--reset-wrapper` on the right. The Algolia theme CSS gives
+   the input enough horizontal padding to clear those icons, but the global
+   form rule in Section 8 forces `padding: 0.75rem 1rem !important` on every
+   text input, which strips that padding and lets the typed text slide under
+   the magnifier icon. Restore the horizontal padding (left for the
+   magnifier, right for the reset X) and re-skin the input with our design
+   tokens. The v3 `.ais-SearchBox-*` class names are listed alongside the v2
+   ones so the rules survive a future widget upgrade.
+   -------------------------------------------------------------------------- */
+.search-content .search-searchbar .ais-search-box,
+.search-content .search-searchbar .ais-SearchBox {
+  max-width: 100% !important;
+  margin: 0 0 1.5rem !important;
+}
+
+.search-content input.ais-search-box--input,
+.search-content input.ais-SearchBox-input {
+  display: block;
+  width: 100% !important;
+  box-sizing: border-box !important;
+  padding: 0.75rem 2.6rem !important;
+  font-family: var(--font-sans) !important;
+  font-size: 1rem !important;
+  line-height: 1.4 !important;
+  color: var(--text) !important;
+  background: var(--bg) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: var(--radius-md) !important;
+  box-shadow: none !important;
+  transition: border-color var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease);
+}
+
+.search-content input.ais-search-box--input::placeholder,
+.search-content input.ais-SearchBox-input::placeholder {
+  color: var(--text-muted);
+  opacity: 1;
+}
+
+.search-content input.ais-search-box--input:hover,
+.search-content input.ais-SearchBox-input:hover {
+  border-color: var(--border-strong) !important;
+}
+
+.search-content input.ais-search-box--input:focus,
+.search-content input.ais-SearchBox-input:focus {
+  outline: none !important;
+  border-color: var(--accent) !important;
+  box-shadow: 0 0 0 4px var(--accent-soft) !important;
+}
+
+/* Magnifier and reset icon buttons — neutral muted color, vertically
+   centred inside the input. Their absolute positioning comes from the
+   bundled Algolia theme stylesheet; we only retint them here. */
+.search-content .ais-search-box--magnifier-wrapper,
+.search-content .ais-search-box--reset-wrapper,
+.search-content .ais-SearchBox-submit,
+.search-content .ais-SearchBox-reset {
+  color: var(--text-muted);
+  background: transparent;
+  border: 0;
+}
+
+.search-content .ais-search-box--magnifier,
+.search-content .ais-search-box--reset,
+.search-content .ais-SearchBox-submitIcon,
+.search-content .ais-SearchBox-resetIcon {
+  fill: currentColor;
+}
+
+.search-content .ais-search-box--magnifier-wrapper:hover,
+.search-content .ais-search-box--reset-wrapper:hover,
+.search-content .ais-SearchBox-submit:hover,
+.search-content .ais-SearchBox-reset:hover {
+  color: var(--accent);
+}

--- a/_tips/2023-01-11-cht-sh-cli.md
+++ b/_tips/2023-01-11-cht-sh-cli.md
@@ -65,16 +65,4 @@ Pretty cool, huh? Below is an illustration on running **cht.sh** for different q
 
 If you liked this post you can subscribe to the mailing list below to get similar updates from time to time.
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_tips/2023-01-12-explain-shell.md
+++ b/_tips/2023-01-12-explain-shell.md
@@ -48,19 +48,7 @@ explanations. We can see one example in the image below:
 
 If you liked this post you can subscribe to the mailing list below to get similar updates from time to time.
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 # Postscriptum
 

--- a/_tips/2023-01-19-umap-explorer.md
+++ b/_tips/2023-01-19-umap-explorer.md
@@ -104,22 +104,10 @@ I wish we had more of these interactive data explorers.
 
 If this is something you like and would like to see similar content you could follow me on 
 <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener">LinkedIn</a>
-or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>. 
+or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>. 
 Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 
 # Resources

--- a/_tips/2023-01-22-loss-per-class.md
+++ b/_tips/2023-01-22-loss-per-class.md
@@ -52,20 +52,8 @@ We can observe that the model is learning `class 1` (which represents an `automo
 
 The source code for the implementation can be found on <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Visualizations/loss_per_class.ipynb" target="_blank">GitHub</a>.
 If this is something you like and would like to see similar content you could follow me on <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener">LinkedIn</a>
-or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
+or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
 
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>

--- a/_tips/2023-01-26-pandas-plotting.md
+++ b/_tips/2023-01-26-pandas-plotting.md
@@ -88,20 +88,8 @@ The resulting plots are shown below:
 
 The source code for this work can be found in this <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Visualizations/pandas_plotting.ipynb" target="_blank" rel="dofollow noopener"><b>Jupyter Notebook</b></a>.
 If this is something you like and would like to see similar content you could follow me on <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener"><b>LinkedIn</b></a>
-or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener"><b>Twitter</b></a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
+or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener"><b>Twitter</b></a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
 
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>

--- a/_tips/2023-01-27-altair-plotting.md
+++ b/_tips/2023-01-27-altair-plotting.md
@@ -95,20 +95,8 @@ The resulting plot is depicted below:
 
 The source code for this work can be found in this <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Visualizations/altair_plotting.ipynb" target="_blank" rel="dofollow noopener">Jupyter Notebook</a>.
 If this is something you like and would like to see similar content you could follow me on <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener"><b>LinkedIn</b></a>
-or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener"><b>Twitter</b></a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
+or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener"><b>Twitter</b></a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
 
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>

--- a/_tips/2023-02-06-python-profilers.md
+++ b/_tips/2023-02-06-python-profilers.md
@@ -146,20 +146,8 @@ Finally, [pyinstrument](https://github.com/joerick/pyinstrument){:target="_blank
 
 The source code for this work can be found in this <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Profiling/profilers_experiments.ipynb" target="_blank" rel="dofollow noopener">Jupyter Notebook</a>.
 If this is something you like and would like to see similar content you could follow me on <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener"><b>LinkedIn</b></a>
-or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener"><b>Twitter</b></a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
+or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener"><b>Twitter</b></a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
 
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>

--- a/_tips/2023-02-07-chatgpt-latex.md
+++ b/_tips/2023-02-07-chatgpt-latex.md
@@ -87,20 +87,8 @@ torch.allclose(res_chatgpt, res_reference)  # prints `True`
 
 
 If this is something you like and would like to see similar content you could follow me on <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener"><b>LinkedIn</b></a>
-or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener"><b>Twitter</b></a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
+or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener"><b>Twitter</b></a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
 
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>

--- a/_tips/2023-02-12-walrus-operator.md
+++ b/_tips/2023-02-12-walrus-operator.md
@@ -107,20 +107,8 @@ The resulting plot is the one depicted below:
 
 The source code for this work can be found in this <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Visualizations/jax_gradient_with_walrus_op.ipynb" target="_blank" rel="dofollow noopener"><b>Jupyter Notebook</b></a>.
 If this is something you like and would like to see similar content you could follow me on <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener"><b>LinkedIn</b></a>
-or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener"><b>Twitter</b></a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
+or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener"><b>Twitter</b></a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
 
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>

--- a/_tips/2023-02-19-chatgpt-derivation.md
+++ b/_tips/2023-02-19-chatgpt-derivation.md
@@ -123,20 +123,8 @@ np.allclose(fp_chatgpt, fp_jax, atol=1.e-5)  # prints True
 
 The source code for this work can be found in this
 <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Differentiation/derivatives_with_chatgpt.ipynb" target="_blank" rel="dofollow noopener">Jupyter Notebook</a>. If this is something you like and would like to see similar content you could follow me on <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener"><b>LinkedIn</b></a>
-or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener"><b>Twitter</b></a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
+or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener"><b>Twitter</b></a>. Additionally, you can subscribe to the mailing list below to get similar updates from time to time.
 
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>

--- a/_visualizations/2020-02-08-parallel-coordinates.html
+++ b/_visualizations/2020-02-08-parallel-coordinates.html
@@ -36,7 +36,7 @@ header:
 <p>
     The full code to run this interactive visualization can be found
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/tree/master/Interactive%20Dataviz" target="_blank" rel=”noopener”>here.</a>
-     For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+     For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -44,16 +44,4 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_visualizations/2020-03-24-jdk-graphviz.html
+++ b/_visualizations/2020-03-24-jdk-graphviz.html
@@ -41,7 +41,7 @@ header:
 <p>
     The full code and data can be found in the following
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/tree/master/JavaScript%20Visualization%20Zoo" target="_blank" rel="noopener">GitHub repo</a>.
-    For more information, follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="nofollow noopener">Twitter</a>.
+    For more information, follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="nofollow noopener">Twitter</a>.
 </p>
 
 
@@ -50,16 +50,4 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_visualizations/2020-04-12-random-walk.html
+++ b/_visualizations/2020-04-12-random-walk.html
@@ -32,7 +32,7 @@ header:
 <p>The full source code behind this random walk animation can be found in this
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Random%20Processes/random_walk_animation.ipynb" target="_blank" rel="dofollow noopener">Python Notebook</a>.
     For more information, please follow me on
-    <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -40,16 +40,4 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_visualizations/2020-04-16-brownian-motion-convergence.html
+++ b/_visualizations/2020-04-16-brownian-motion-convergence.html
@@ -33,7 +33,7 @@ header:
 <p>
     The full source code related to all we have discussed during this blog can be found on
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Random%20Processes/brownian_motion_animation.ipynb", target="_blank" rel="dofollow noopener">GitHub</a>.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -41,16 +41,4 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_visualizations/2020-05-01-brownian-motion-bias.html
+++ b/_visualizations/2020-05-01-brownian-motion-bias.html
@@ -33,7 +33,7 @@ header:
 <p>
     The full source code behind this simulation and animations can be found on my
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Random%20Processes/drifted_brownian_motion.ipynb" target="_blank" rel="dofollow noopener">Python Notebook</a>.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -41,16 +41,4 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_visualizations/2020-05-01-brownian-motion-volatility.html
+++ b/_visualizations/2020-05-01-brownian-motion-volatility.html
@@ -31,7 +31,7 @@ header:
 <p>
     The full source code behind this simulation and animations can be found on my
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Random%20Processes/drifted_brownian_motion.ipynb" target="_blank" rel="dofollow noopener">Python Notebook</a>.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -39,16 +39,4 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_visualizations/2020-05-04-approximation-pi.html
+++ b/_visualizations/2020-05-04-approximation-pi.html
@@ -33,7 +33,7 @@ header:
     Although this has a nice geometrical interpretation, it is not an effective method to approximate <i>Pi</i>.
     The source code related this visualization can be found in this
     <a href="https://gist.github.com/IlievskiV/ea5a97866ec0caa744430e7696191e09" target="_blank" rel="dofollow noopener">GitHub Gist</a>.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -41,16 +41,4 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_visualizations/2020-05-17-gbm-mean-var.html
+++ b/_visualizations/2020-05-17-gbm-mean-var.html
@@ -32,7 +32,7 @@ header:
 <p>
     The source code related to this visualization can be found on
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Random%20Processes/geometric_brownian_motion.ipynb", target="_blank" rel="dofollow noopener">GitHub</a>.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -40,16 +40,4 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_visualizations/2020-05-19-gbm-monte-carlo.html
+++ b/_visualizations/2020-05-19-gbm-monte-carlo.html
@@ -36,7 +36,7 @@ header:
 <p>
     The source code related to this visualization can be found on
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Random%20Processes/geometric_brownian_motion.ipynb", target="_blank" rel="dofollow noopener">GitHub</a>.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -44,16 +44,4 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_visualizations/2020-05-22-bm-reflection-principle.html
+++ b/_visualizations/2020-05-22-bm-reflection-principle.html
@@ -34,7 +34,7 @@ header:
 <p>
     The source code related this visualization can be found in this
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Visualizations/reflection_principle_bm.ipynb" target="_blank" rel="dofollow noopener">Jupyter Notebook</a>.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -42,16 +42,4 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_visualizations/2020-05-27-riemann-sums.html
+++ b/_visualizations/2020-05-27-riemann-sums.html
@@ -34,7 +34,7 @@ header:
 <p>
     The source code related this visualization can be found on
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Integration/riemann_sums.ipynb" target="_blank" rel="dofollow noopener">GitHub</a>.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -42,16 +42,4 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_visualizations/2020-06-07-area-circle.html
+++ b/_visualizations/2020-06-07-area-circle.html
@@ -42,7 +42,7 @@ header:
 <p>
     The source code related this visualization can be found in this
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Visualizations/calculate_area_animation.ipynb" target="_blank" rel="dofollow noopener">Python Notebook</a>.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -50,16 +50,4 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_visualizations/2020-06-11-mandelbrot.html
+++ b/_visualizations/2020-06-11-mandelbrot.html
@@ -47,7 +47,7 @@ header:
 <p>
     The source code related this visualization can be found in this
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Visualizations/mandelbrot.ipynb" target="_blank" rel="dofollow noopener">Python Notebook</a>.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -55,16 +55,4 @@ header:
     spammed that's a promise! You will get updates for the newest blog posts and visualizations from time to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_visualizations/2020-06-15-koch-curve.html
+++ b/_visualizations/2020-06-15-koch-curve.html
@@ -63,16 +63,4 @@ header:
     to time.
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_visualizations/2020-06-26-julia-set.html
+++ b/_visualizations/2020-06-26-julia-set.html
@@ -80,16 +80,4 @@ header:
     Thanks for reading this article!
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}

--- a/_visualizations/2020-11-18-bufurcation-diagram.html
+++ b/_visualizations/2020-11-18-bufurcation-diagram.html
@@ -67,7 +67,7 @@ header:
 <p>
     The source code for these animations can be found in this
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Visualizations/bifurcation_diagram.ipynb" target="_blank" rel="dofollow noopener">Jupyter Notebook</a>.
-    For more information, please follow me on <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>
+    For more information, please follow me on <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>
     or <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener">LinkedIn</a>.
 </p>
 
@@ -77,19 +77,7 @@ header:
     You will get cool animations like this one from time to time. Thanks for reading this article!
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 <h2>References</h2>
 

--- a/_visualizations/2021-02-25-riemann-zeta-zeros.html
+++ b/_visualizations/2021-02-25-riemann-zeta-zeros.html
@@ -110,7 +110,7 @@ header:
     The source code for this animation of the zeros of the Riemann Zeta function can be found in this
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Visualizations/riemann_zeta_zeros.ipynb" target="_blank" rel="dofollow noopener">Jupyter Notebook</a>.
     For more information, please follow me on <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener">LinkedIn</a>
-    or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+    or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 </p>
 
 <p>
@@ -119,19 +119,7 @@ header:
     And finally, thanks for reading this article!
 </p>
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 <h2>Appendix: Absurd or not?</h2>
 

--- a/_visualizations/2021-12-24-sierpinski-triangle.html
+++ b/_visualizations/2021-12-24-sierpinski-triangle.html
@@ -200,23 +200,11 @@ header:
     The source code for this animation of the Sierpiński triangle
     <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Visualizations/sierpinski_triangle.ipynb" target="_blank" rel="dofollow noopener">Jupyter Notebook</a>.
     For more information, please follow me on <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener">LinkedIn</a>
-    or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>. Additionally, you can subscribe to the mailing list below.
+    or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>. Additionally, you can subscribe to the mailing list below.
 </p>
 
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 
 <h2>Appendix: Sierpinski triangle from cellular automata</h2>
 <p>

--- a/_visualizations/2023-01-13-barnsley-fern.md
+++ b/_visualizations/2023-01-13-barnsley-fern.md
@@ -148,23 +148,11 @@ The source code for this work can be found in this
 <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Visualizations/barnsley_fern.ipynb" target="_blank" rel="dofollow noopener">Jupyter Notebook</a>.
 It would be very helpful to star the repo to get more easily noticed. For more information, please follow me on
 <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener">LinkedIn</a>
-or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
+or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener">Twitter</a>.
 
 If you like this content you can subscribe to the mailing list below to get similar updates from time to time.
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>
 
 # Appendix: Other types of fern fractals

--- a/_visualizations/2023-01-30-sdutent-to-gaussian-convergence.md
+++ b/_visualizations/2023-01-30-sdutent-to-gaussian-convergence.md
@@ -117,23 +117,11 @@ The source code for this work can be found in this
 <a href="https://github.com/IlievskiV/Amusive-Blogging-N-Coding/blob/master/Visualizations/student_to_gaussian_convergence.ipynb" target="_blank" rel="dofollow noopener">Jupyter Notebook</a>.
 It would be very helpful to star the repo to get more easily noticed. For more information, please follow me on
 <a href="https://www.linkedin.com/in/vilievski/" target="_blank" rel="noopener"><b>LinkedIn</b></a>
-or <a href="https://twitter.com/VladOsaurus" target="_blank" rel="noopener"><b>Twitter</b></a>.
+or <a href="https://x.com/VladOsaurus" target="_blank" rel="noopener"><b>Twitter</b></a>.
 
 If you like this content you can subscribe to the mailing list below to get similar updates from time to time.
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
+{% include newsletter.html %}
 <br/>
 
 # Interesting fact about the Student's T-distribution

--- a/assets/css/mailchimp.css
+++ b/assets/css/mailchimp.css
@@ -1,6 +1,10 @@
-# mc_embed_signup {
-    background:#fff; clear:left;
-    font-size: 1.35em;
-    font-family: Montserrat, sans-serif;
-    width:250px;
+/* Light tweaks for the Mailchimp embed; the core styling lives in
+   _sass/custom/_modern.scss. Keep this minimal so it can't fight back. */
+#mc_embed_signup {
+  clear: left;
+  width: 100%;
+  max-width: 100%;
+}
+#mc_embed_signup form {
+  font-family: inherit;
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -6,3 +6,4 @@
 
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
 @import "minimal-mistakes"; // main partials
+@import "custom/modern"; // modern remodel overrides

--- a/assets/js/custom/modern.js
+++ b/assets/js/custom/modern.js
@@ -1,0 +1,377 @@
+/* iSquared modern remodel — theme toggle + scroll reveal + nav-shadow */
+(function () {
+  'use strict';
+
+  /* ---------- Theme toggle ---------- */
+  var STORAGE_KEY = 'theme';
+
+  function getStoredTheme() {
+    try {
+      return localStorage.getItem(STORAGE_KEY);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function applyTheme(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+    var meta = document.querySelector('meta[name="theme-color"]:not([media])');
+    if (meta) meta.setAttribute('content', theme === 'dark' ? '#0b1020' : '#ffffff');
+  }
+
+  function initThemeToggle() {
+    var btn = document.querySelector('.theme-toggle');
+    if (!btn) return;
+
+    btn.addEventListener('click', function () {
+      var current = document.documentElement.getAttribute('data-theme') || 'light';
+      var next = current === 'dark' ? 'light' : 'dark';
+      applyTheme(next);
+      try {
+        localStorage.setItem(STORAGE_KEY, next);
+      } catch (e) {}
+    });
+
+    /* React to system theme changes when user has no explicit choice */
+    if (window.matchMedia) {
+      var mq = window.matchMedia('(prefers-color-scheme: dark)');
+      var listener = function (e) {
+        if (!getStoredTheme()) {
+          applyTheme(e.matches ? 'dark' : 'light');
+        }
+      };
+      if (mq.addEventListener) mq.addEventListener('change', listener);
+      else if (mq.addListener) mq.addListener(listener);
+    }
+  }
+
+  /* ---------- Scroll reveal for cards / hero / sections ---------- */
+  function initReveal() {
+    if (!('IntersectionObserver' in window)) return;
+
+    var selectors = [
+      '.feature__item',
+      '.grid__item',
+      '.list__item',
+      '.layout--splash #main > h1',
+      '.layout--splash #main > p',
+      '#mc_embed_signup'
+    ];
+    var nodes = document.querySelectorAll(selectors.join(','));
+    if (!nodes.length) return;
+
+    nodes.forEach(function (n) {
+      n.classList.add('reveal');
+    });
+
+    var io = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-visible');
+            io.unobserve(entry.target);
+          }
+        });
+      },
+      { rootMargin: '0px 0px -8% 0px', threshold: 0.08 }
+    );
+
+    nodes.forEach(function (n) { io.observe(n); });
+  }
+
+  /* ---------- Add a subtle shadow to the nav once the user scrolls ---------- */
+  function initNavShadow() {
+    var nav = document.querySelector('.masthead');
+    if (!nav) return;
+    var update = function () {
+      if (window.scrollY > 8) nav.classList.add('is-scrolled');
+      else nav.classList.remove('is-scrolled');
+    };
+    update();
+    window.addEventListener('scroll', update, { passive: true });
+  }
+
+  /* ---------- Copy button + language label on code blocks ---------- */
+  var COPY_ICON_SVG =
+    '<svg class="icon-copy" viewBox="0 0 24 24" aria-hidden="true" focusable="false">' +
+      '<rect x="9" y="9" width="11" height="11" rx="2"></rect>' +
+      '<path d="M5 15V6a2 2 0 0 1 2-2h9"></path>' +
+    '</svg>';
+  var CHECK_ICON_SVG =
+    '<svg class="icon-check" viewBox="0 0 24 24" aria-hidden="true" focusable="false">' +
+      '<polyline points="20 6 9 17 4 12"></polyline>' +
+    '</svg>';
+
+  /* Pretty-print common language slugs; fall back to capitalized slug. */
+  var LANG_LABELS = {
+    js: 'JavaScript',
+    javascript: 'JavaScript',
+    ts: 'TypeScript',
+    typescript: 'TypeScript',
+    py: 'Python',
+    python: 'Python',
+    rb: 'Ruby',
+    ruby: 'Ruby',
+    sh: 'Shell',
+    bash: 'Bash',
+    zsh: 'Zsh',
+    shell: 'Shell',
+    yml: 'YAML',
+    yaml: 'YAML',
+    json: 'JSON',
+    html: 'HTML',
+    css: 'CSS',
+    scss: 'SCSS',
+    sass: 'Sass',
+    md: 'Markdown',
+    markdown: 'Markdown',
+    cpp: 'C++',
+    'c++': 'C++',
+    c: 'C',
+    cs: 'C#',
+    csharp: 'C#',
+    go: 'Go',
+    rust: 'Rust',
+    rs: 'Rust',
+    java: 'Java',
+    kotlin: 'Kotlin',
+    swift: 'Swift',
+    php: 'PHP',
+    sql: 'SQL',
+    r: 'R',
+    plaintext: 'Text',
+    text: 'Text'
+  };
+
+  function detectLanguage(wrapper) {
+    if (!wrapper || !wrapper.classList) return '';
+    var classes = wrapper.className.split(/\s+/);
+    for (var i = 0; i < classes.length; i++) {
+      var cls = classes[i];
+      if (cls.indexOf('language-') === 0) {
+        return cls.slice('language-'.length).toLowerCase();
+      }
+    }
+    return '';
+  }
+
+  function prettyLangLabel(slug) {
+    if (!slug) return 'Code';
+    if (LANG_LABELS[slug]) return LANG_LABELS[slug];
+    return slug.charAt(0).toUpperCase() + slug.slice(1);
+  }
+
+  function fallbackCopy(text) {
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'absolute';
+    ta.style.left = '-9999px';
+    ta.style.top = '0';
+    document.body.appendChild(ta);
+    var prevSelection = document.getSelection();
+    var prevRange =
+      prevSelection && prevSelection.rangeCount > 0
+        ? prevSelection.getRangeAt(0)
+        : null;
+    ta.select();
+    var ok = false;
+    try {
+      ok = document.execCommand('copy');
+    } catch (e) {
+      ok = false;
+    }
+    document.body.removeChild(ta);
+    if (prevRange && prevSelection) {
+      prevSelection.removeAllRanges();
+      prevSelection.addRange(prevRange);
+    }
+    return ok ? Promise.resolve() : Promise.reject(new Error('copy failed'));
+  }
+
+  function copyText(text) {
+    if (
+      navigator.clipboard &&
+      typeof navigator.clipboard.writeText === 'function' &&
+      window.isSecureContext !== false
+    ) {
+      return navigator.clipboard.writeText(text).catch(function () {
+        return fallbackCopy(text);
+      });
+    }
+    return fallbackCopy(text);
+  }
+
+  function flashState(btn, stateClass, duration) {
+    btn.classList.remove('is-copied', 'is-error');
+    btn.classList.add(stateClass);
+    if (btn._copyTimer) {
+      clearTimeout(btn._copyTimer);
+    }
+    btn._copyTimer = setTimeout(function () {
+      btn.classList.remove(stateClass);
+      btn._copyTimer = null;
+    }, duration);
+  }
+
+  /* Extract clean code text from a Rouge wrapper, excluding any line-number
+     gutter. Rouge's `line_table` mode renders:
+       <table class="rouge-table">
+         <tr>
+           <td class="gutter gl"><pre class="lineno">1\n2\n…</pre></td>
+           <td class="code"><pre>actual code…</pre></td>
+         </tr>
+       </table>
+     Older / alternative configs may use `.rouge-gutter` and `.rouge-code`
+     instead, so we accept both. The plain (no-linenos) variant has no table
+     at all and we just read the inner <code>. */
+  function extractCodeText(wrapper, codeEl) {
+    var codeCell = wrapper.querySelector(
+      '.rouge-table td.rouge-code, .rouge-table td.code, .rouge-code'
+    );
+    var source = codeCell || codeEl;
+    if (!source) return '';
+
+    var inner = source.querySelector('pre') || source;
+    var clone = inner.cloneNode(true);
+
+    var stripSelector =
+      '.rouge-gutter, .gutter, .gl, .lineno, td.rouge-gutter, td.gutter';
+    var junk = clone.querySelectorAll(stripSelector);
+    Array.prototype.forEach.call(junk, function (node) {
+      if (node.parentNode) node.parentNode.removeChild(node);
+    });
+
+    var text = clone.innerText || clone.textContent || '';
+    return text.replace(/\n$/, '');
+  }
+
+  function initCodeCopy() {
+    var wrappers = document.querySelectorAll(
+      '.highlighter-rouge, figure.highlight'
+    );
+    if (!wrappers.length) return;
+
+    Array.prototype.forEach.call(wrappers, function (wrapper) {
+      if (wrapper.getAttribute('data-copy-init') === '1') return;
+
+      var codeEl = wrapper.querySelector('pre code, code');
+      if (!codeEl) return;
+
+      var lang = detectLanguage(wrapper);
+      var label = prettyLangLabel(lang);
+
+      var header = document.createElement('div');
+      header.className = 'code-block-header';
+
+      var langSpan = document.createElement('span');
+      langSpan.className = 'code-block-lang';
+      langSpan.textContent = label;
+
+      var btn = document.createElement('button');
+      btn.className = 'code-copy-btn';
+      btn.type = 'button';
+      btn.setAttribute('aria-label', 'Copy code');
+      btn.setAttribute('title', 'Copy code');
+      btn.innerHTML =
+        COPY_ICON_SVG + CHECK_ICON_SVG + '<span class="sr-only">Copy code</span>';
+
+      btn.addEventListener('click', function () {
+        var text = extractCodeText(wrapper, codeEl);
+        copyText(text).then(
+          function () {
+            flashState(btn, 'is-copied', 1400);
+          },
+          function () {
+            flashState(btn, 'is-error', 1400);
+          }
+        );
+      });
+
+      header.appendChild(langSpan);
+      header.appendChild(btn);
+
+      wrapper.classList.add('has-copy-btn');
+      wrapper.insertBefore(header, wrapper.firstChild);
+      wrapper.setAttribute('data-copy-init', '1');
+    });
+  }
+
+  /* ---------- Heading anchor icon ----------
+     Minimal Mistakes' bundled `main.min.js` injects a `.header-link` anchor
+     into every `.page__content` heading whose innerHTML is
+       `<span class="sr-only">Permalink</span><i class="fa fa-link"></i>`.
+     The site's stylesheet does not define `.sr-only` globally, so the
+     literal word "Permalink" leaks through and is visible next to every
+     heading. We rewrite each `.header-link` to use an inline SVG chain
+     icon (no Font Awesome dependency) and keep an `sr-only` label for
+     assistive tech. A short-lived MutationObserver covers the case where
+     `main.min.js` (loaded `async`) inserts the anchors after this script
+     runs. */
+  var LINK_ICON_SVG =
+    '<svg class="icon-link" viewBox="0 0 24 24" aria-hidden="true" focusable="false" ' +
+      'fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+      '<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>' +
+      '<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>' +
+    '</svg>';
+
+  function rewriteHeaderLink(anchor) {
+    if (!anchor || anchor.getAttribute('data-icon-rewritten') === '1') return;
+    anchor.innerHTML = LINK_ICON_SVG + '<span class="sr-only">Permalink</span>';
+    anchor.setAttribute('aria-label', 'Permalink');
+    anchor.setAttribute('title', 'Permalink');
+    anchor.setAttribute('data-icon-rewritten', '1');
+  }
+
+  function rewriteAllHeaderLinks(scope) {
+    var root = scope || document;
+    var anchors = root.querySelectorAll('.page__content .header-link');
+    Array.prototype.forEach.call(anchors, rewriteHeaderLink);
+  }
+
+  function initHeaderLinkIcon() {
+    rewriteAllHeaderLinks();
+
+    var content = document.querySelector('.page__content');
+    if (!content || typeof MutationObserver === 'undefined') return;
+
+    var observer = new MutationObserver(function (mutations) {
+      var rescan = false;
+      for (var i = 0; i < mutations.length; i++) {
+        var added = mutations[i].addedNodes;
+        for (var j = 0; j < added.length; j++) {
+          var node = added[j];
+          if (!node || node.nodeType !== 1) continue;
+          if (node.classList && node.classList.contains('header-link')) {
+            rewriteHeaderLink(node);
+          } else if (node.querySelector && node.querySelector('.header-link')) {
+            rescan = true;
+          }
+        }
+      }
+      if (rescan) rewriteAllHeaderLinks(content);
+    });
+
+    observer.observe(content, { childList: true, subtree: true });
+
+    /* The async `main.min.js` finishes well before this. Disconnect after a
+       short window so the observer doesn't keep watching the post forever. */
+    setTimeout(function () {
+      rewriteAllHeaderLinks(content);
+      observer.disconnect();
+    }, 3000);
+  }
+
+  function ready(fn) {
+    if (document.readyState !== 'loading') fn();
+    else document.addEventListener('DOMContentLoaded', fn);
+  }
+
+  ready(function () {
+    initThemeToggle();
+    initReveal();
+    initNavShadow();
+    initCodeCopy();
+    initHeaderLinkIcon();
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 layout: splash
-title: "Welcome to iSquared"
+title: "iSquared — Science, visualized"
 permalink: /
 header:
   overlay_image: /assets/images/penrose_tiling.png
@@ -8,147 +8,109 @@ header:
   og_image: /assets/images/penrose_tiling.png
   caption: "Penrose Tiling. Credits: Matt DuDonis"
   actions:
-    - label: "Read Blog"
+    - label: "Read the Blog"
       url: /blog/
-    - label: "See Visualizations"
+    - label: "Explore Visualizations"
       url: /visualizations/
-    - label: "Geeky Coffee Break"
+    - label: "Quick Tips"
       url: /tips/
-excerpt: A place for ... <br/> Explainable science to go from "I think I understand" to "Now I fully understand". <br/><br/> 
-        To see more scroll down or click on the buttons bellow. Enjoy!
-description: "Explaining science visually"
+excerpt: "Explainable science with bold visualizations and open-source code &mdash; from “I think I get it” to “Now I really do.”"
+description: "Explaining science visually — blog posts, animated visualizations and quick tips on machine learning, math and data."
 
 feature_row_top:
   - image_path: assets/images/black_body_radiation.png
     alt: "Image for blog"
     title: "Blog Posts"
-    excerpt: "Theory, intuition, plots, animations and an open-source code on different topics."
+    excerpt: "Long-form, illustrated deep dives. Theory, intuition, plots, animations and open-source code."
     url: "/blog/"
     btn_class: "btn--info"
-    btn_label: "Read More"
+    btn_label: "Read the blog"
   - image_path: assets/images/calculate_circle_area.png
     alt: "Image for Visualization"
     title: "Visualizations"
-    excerpt: "Atomic and ready-to-use visualizations on different concepts."
+    excerpt: "Atomic, ready-to-use visualizations of scientific and mathematical concepts."
     url: "/visualizations/"
     btn_class: "btn--info"
-    btn_label: "Read More"
+    btn_label: "See visualizations"
   - image_path: assets/images/symmetric_exponential_functions.png
     alt: "Image for Exponential Growth"
-    title: "Quick Tips and Tricks"
-    excerpt: "Short but useful data science and programming tips, tricks and tools."
+    title: "Quick Tips"
+    excerpt: "Bite-size data science and programming tricks &mdash; perfect for a coffee break."
     url: "/tips/"
     btn_class: "btn--info"
-    btn_label: "Read More"
+    btn_label: "Geeky coffee break"
 
 feature_row_blogs:
     - image_path: assets/images/ca_teaser.png
       alt: "Teaser image with cellular automata on it"
       title: "Simple but Stunning: Animated Cellular Automata in Python"
-      excerpt: "Illustration, implementation and animation of the elementary cellular automata in Python with Matplotlib.<br/> We learn the concept of the cellular automata through illustrated examples and provide
-                an implementation and animation in Python with Matplotlib"
+      excerpt: "Illustration, implementation and animation of elementary cellular automata in Python with Matplotlib."
       url: "/blog/2021-05-02-cellular-automata"
       btn_class: "btn--info"
-      btn_label: "Read More"
+      btn_label: "Read more"
     - image_path: assets/images/brownian_motion_teaser.png
       alt: "Teaser image with Brownian motion on it"
       title: "Animated Visualization of Brownian Motion in Python"
-      excerpt: "Animation and visualization of Brownian Motion in Python with Matplotlib.<br/> Tutorial on Brownian Motion using Python using Matplotlib to animate the Brownian Motion construction."
+      excerpt: "Tutorial on Brownian Motion using Matplotlib to animate the construction step by step."
       url: "/blog/2020-04-16-brownian-motion"
       btn_class: "btn--info"
-      btn_label: "Read More"
+      btn_label: "Read more"
     - image_path: assets/images/interactive_visualization_teaser.jpg
       alt: "Teaser image with radial stacked bar chart"
       title: "The importance of interactive data visualization"
-      excerpt: "Hands-on experience with D3.js to create a Parallel Coordinates plot. <br/> A general overview of the interactive visualization for multivariate
-                data with a live demo of the Parallel Coordinates plot using D3 JS."
+      excerpt: "Hands-on D3.js: building a Parallel Coordinates plot from scratch with a live demo."
       url: "/blog/2020-02-08-interactive-dataviz"
       btn_class: "btn--info"
-      btn_label: "Read More"
+      btn_label: "Read more"
 
 feature_row_visualizations:
       - image_path: assets/images/koch_snowflake.png
         alt: "Teaser image with the Kock snowflake on it"
-        title: "Visualized Koch Snowflake in Python with Matplotlib"
-        excerpt: "Learn how to implement a Koch Snowflake in Python and how to animate it using Matplotlib."
+        title: "Koch Snowflake in Python with Matplotlib"
+        excerpt: "Implement the Koch Snowflake in Python and animate it with Matplotlib."
         url: "/visualizations/2020-06-15-koch-curve"
         btn_class: "btn--info"
-        btn_label: "See Visualization"
+        btn_label: "See visualization"
       - image_path: assets/images/bifurcation.png
         alt: "Teaser image with the bifurcation diagram on it"
-        title: "Chaotic Beauty: Bifurcation Diagram Animation with Matplotlib"
-        excerpt: "How to visualize the bifurcation diagram of a simple logistic map in Python with Matplotlib"
+        title: "Chaotic Beauty: Bifurcation Diagram"
+        excerpt: "Visualize the bifurcation diagram of a simple logistic map with Matplotlib."
         url: "/visualizations/2020-11-18-bufurcation-diagram"
         btn_class: "btn--info"
-        btn_label: "See Visualization"
+        btn_label: "See visualization"
       - image_path: assets/images/julia_set.png
         alt: "Teaser image with the Julia fractal on it"
-        title: "Julia Set: Animate your own in Python with Matplotlib"
-        excerpt: "The mind-gobbling properties of the Julia Set through the prism of visualization"
+        title: "Julia Set: Animate your own"
+        excerpt: "The mind-bending properties of the Julia Set through the prism of visualization."
         url: "/visualizations/2020-06-26-julia-set"
         btn_class: "btn--info"
-        btn_label: "See Visualization"
+        btn_label: "See visualization"
 ---
 
 
-<h1>What's here?</h1>
-<p>Find interesting blogs, visualizations, simple tips and tricks and programming resources in <b>Python</b> and <b>Javascript</b>.
-Everything is free for use for non-commercial purposes. The only requirement is to provide a <b>reference</b> to this site.</p>
-<br/>
+<h1>What's here</h1>
+<p>A collection of <strong>blog posts</strong>, <strong>visualizations</strong> and <strong>quick tips</strong> in <strong>Python</strong> and <strong>JavaScript</strong>. Everything is free for non-commercial use &mdash; just credit the site.</p>
 
 {% include feature_row id="feature_row_top" %}
 
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Like what you see here? Subscribe to the mailing list!</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
-<br/>
 
-
-<h1>Popular Blogs</h1>
-<p>Here's a list of the most popular blogs:</p>
+<h1>Popular blog posts</h1>
+<p>A few favourites from the archive.</p>
 {% include feature_row id="feature_row_blogs" type="left" %}
 
 
-
-<h1>Some Interesting Visualizations</h1>
+<h1>Featured visualizations</h1>
+<p>Hand-picked visualizations to play with.</p>
 {% include feature_row id="feature_row_visualizations" type="left" %}
 
+
 <h1>About iSquared</h1>
-<figure style="width: full;">
-  <img data-src="{{ site.url }}{{ site.baseurl }}/assets/logos/isquared_logo_header.jpeg" class="lazyload" alt="Website logo">
-</figure>
-<br/>
+<p><strong>iSquared</strong> is a place to perceive science through interesting visualisations. Each piece explains the concept, implements it in code, and shows it in motion. The goal: make ideas easy to grasp.</p>
+
+<p>Curious about the author? Head over to the <a href="/whoami/">$whoami</a> page.</p>
 
 
-<p><b>iSquared</b> is a place to perceive science through interesting visualisations. It explains and implements the visualised concepts. 
-The goal is to make the concepts easy to grasp. This could serve as an excellent learning and programming resource.</p>
+<h1>Stay in the loop</h1>
+<p>Get new posts, visualizations and tips straight to your inbox &mdash; no spam, ever.</p>
 
-<p>If you are interested to more about the author of <b>iSquared</b>, check the <a href="/whoami/">$whoami</a> section.</p>
-
-<h1>Subscribe</h1>
-<p>If <b>iSquared</b> seems interesting to you, please subscribe to the mailing list below.</p>
-
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<link href="/assets/css/mailchimp.css">
-<div id="mc_embed_signup">
-<form action="https://digital.us19.list-manage.com/subscribe/post?u=cb9dbe40387c27177a25de80f&amp;id=08bda6f8e0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<label for="mce-EMAIL">Join the iSquared mailing list</label>
-	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb9dbe40387c27177a25de80f_08bda6f8e0" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
-
+{% include newsletter.html %}

--- a/scripts/replace_newsletter.py
+++ b/scripts/replace_newsletter.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Replace hardcoded Mailchimp signup blocks in posts with a Liquid include.
+
+Usage:
+    python3 scripts/replace_newsletter.py [--dry-run]
+
+Walks `_blog`, `_visualizations`, `_tips` and rewrites every matching block
+with `{% include newsletter.html %}`. Idempotent: if a file no longer contains
+the hardcoded block, it is left untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TARGET_DIRS = ["_blog", "_visualizations", "_tips"]
+INCLUDE_TAG = "{% include newsletter.html %}"
+
+# The hardcoded Mailchimp block opens with one of these <link ...> tags
+# (sometimes only one of them is present) and closes with the </div> that
+# terminates the #mc_embed_signup wrapper.
+BLOCK_PATTERN = re.compile(
+    r"""
+    (?:[ \t]*<link\s+href=["']//cdn-images\.mailchimp\.com/embedcode/[^>]*>\s*)?  # optional CDN link
+    (?:[ \t]*<link\s+href=["']/assets/css/mailchimp\.css["'][^>]*>\s*)?            # optional local link
+    [ \t]*<div\s+id=["']mc_embed_signup["'][^>]*>     # opening wrapper
+    .*?                                               # form body
+    </form>\s*</div>                                  # closing wrapper
+    """,
+    re.DOTALL | re.VERBOSE,
+)
+
+
+def process_file(path: Path, dry_run: bool) -> int:
+    """Return the number of replacements made in `path`."""
+    text = path.read_text(encoding="utf-8")
+    new_text, n = BLOCK_PATTERN.subn(INCLUDE_TAG, text)
+    if n == 0:
+        return 0
+    if not dry_run:
+        path.write_text(new_text, encoding="utf-8")
+    return n
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would change without writing files",
+    )
+    args = parser.parse_args()
+
+    total_files = 0
+    total_replacements = 0
+    for rel_dir in TARGET_DIRS:
+        directory = ROOT / rel_dir
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.iterdir()):
+            if path.suffix.lower() not in {".html", ".md"}:
+                continue
+            n = process_file(path, dry_run=args.dry_run)
+            if n:
+                total_files += 1
+                total_replacements += n
+                print(f"{path.relative_to(ROOT)}: {n} replacement(s)")
+
+    suffix = " (dry run)" if args.dry_run else ""
+    print(
+        f"\nTotal: {total_replacements} replacement(s) across "
+        f"{total_files} file(s){suffix}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Full modern remodel of the site (Jekyll + Minimal Mistakes):

- New design tokens, typography, and dark-mode toggle with system-preference + persistence.
- Glassmorphism masthead with logo restored; tightened nav padding; subtle whoami CTA.
- Animated-gradient hero, redesigned card grids for blog/visualizations/tips collections (no more zig-zag), increased card spacing.
- New reusable newsletter signup component (homepage + sidebar + bulk-replaced inside legacy posts via scripts/replace_newsletter.py).
- Restyled contact form to match the newsletter card.
- Replaced Font Awesome `<i>` brand icons with inline SVGs in author profile, footer, social share, and CV/whoami page.
- Tag-based related-posts include (works across the custom blog/visualizations/tips collections).
- New /tags/ archive page with tag cloud + per-tag anchored sections; restored stripped href on tag/category list includes.
- Code-block copy button with `.rouge-code` extraction so copies omit line numbers; gutter is also unselectable for manual copy.
- Heading anchor links replaced with hover chain SVG (no FA dependency).
- Custom modern 404 page.
- Bulk-replaced twitter.com with x.com across all posts and configs.
- QA polish: dark/light theme-color meta wired so URL bar tints on toggle; /tags/ back-to-top hrefs use `#page-title`; sidebar `s` loop variable renamed to `sb`; redundant `or contains x.com` clause cleaned; stray `s` literal in disqus include removed; Algolia overlay input padded so the magnifier no longer overlaps typed text.